### PR TITLE
[Feature]: Enable print functionality

### DIFF
--- a/app/locales/en/songs.json
+++ b/app/locales/en/songs.json
@@ -5,6 +5,7 @@
     "parts": "Parts",
     "language": "Language",
     "editChords": "Edit chords",
+    "viewChords": "View chords",
     "organization": "Organization"
   },
   "actions": {
@@ -14,7 +15,13 @@
     "copyToOrganization": "Copy to different organization",
     "view": "View song",
     "preview": "Preview song",
-    "close": "Close"
+    "print": "Print",
+    "close": "Close",
+    "increaseFont": "Increase font size",
+    "resetFont": "Reset font size",
+    "decreaseFont": "Decrease font size",
+    "numbers": "Show numbers",
+    "compact": "Compact equal parts"
   },
   "button": {
     "add": "Add",
@@ -67,5 +74,8 @@
   "organizations": {
     "defaultName": "Personal space",
     "publicArchive": "Public archive"
+  },
+  "print": {
+    "sequence": "Sequence"
   }
 }

--- a/app/locales/pt/songs.json
+++ b/app/locales/pt/songs.json
@@ -5,6 +5,7 @@
     "parts": "Partes",
     "language": "Idioma",
     "editChords": "Editar cifras",
+    "viewChords": "Ver cifras",
     "organization": "Organização"
   },
   "actions": {
@@ -14,7 +15,13 @@
     "copyToOrganization": "Copiar para outra organização",
     "view": "Visualizar música",
     "preview": "Pré-visualizar música",
-    "close": "Fechar"
+    "print": "Imprimir",
+    "close": "Fechar",
+    "increaseFont": "Aumentar fonte",
+    "resetFont": "Redefinir fonte",
+    "decreaseFont": "Diminuir fonte",
+    "numbers": "Mostrar números",
+    "compact": "Compactar partes iguais"
   },
   "button": {
     "add": "Adicionar",
@@ -67,5 +74,8 @@
   "organizations": {
     "defaultName": "Espaço individual",
     "publicArchive": "Acervo público"
+  },
+  "print": {
+    "sequence": "Sequência"
   }
 }

--- a/app/src/components/app/songs/edit-parts.tsx
+++ b/app/src/components/app/songs/edit-parts.tsx
@@ -5,7 +5,7 @@ import { SongSchema } from "@/types/schemas/song.schema";
 import ArrowsUpDownIcon from "@heroicons/react/20/solid/ArrowsUpDownIcon";
 import Square2StackIcon from "@heroicons/react/24/solid/Square2StackIcon";
 import TrashIcon from "@heroicons/react/24/solid/TrashIcon";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useFieldArray, UseFormReturn } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { z } from "zod";
@@ -51,6 +51,15 @@ export default function EditSongParts({
     setNextId(nextId + 1);
   }
 
+  const updateBlocks = () => {
+    const newBlocks = form.getValues('blocks');
+    form.setValue('blocks', newBlocks);
+  }
+
+  useEffect(() => {
+    updateBlocks();
+  }, [mode]);
+
   return (
     <div className="flex flex-col items-stretch space-y-2">
       <Sortable
@@ -72,10 +81,10 @@ export default function EditSongParts({
                       { mode === 'chords' ? (
                         <div className="flex-1 grid grid-cols-1 grid-rows-1 border-input shadow-xs dark:bg-input/30">
                           <Textarea variant="invisible" className="col-start-1 row-start-1 pt-5 pb-0 font-mono leading-[3.2em] pointer-events-none text-muted-foreground" value={blocks[ix].text} />
-                          <Textarea variant="transparent" className="col-start-1 row-start-1 pt-0 pb-5 font-mono leading-[3.2em] min-h-full" {...form.register(`blocks.${ix}.chords`)} />
+                          <Textarea variant="transparent" className="col-start-1 row-start-1 pt-0 pb-5 font-mono leading-[3.2em] min-h-full" {...form.register(`blocks.${ix}.chords`)} onBlur={updateBlocks} />
                         </div>
                       ) : (
-                        <Textarea className="flex-1" {...form.register(`blocks.${ix}.text`)} />
+                        <Textarea className="flex-1" {...form.register(`blocks.${ix}.text`)} onBlur={updateBlocks} />
                       )}
                       <SortableItemHandle asChild>
                         <Button

--- a/app/src/components/ui/button.tsx
+++ b/app/src/components/ui/button.tsx
@@ -22,6 +22,7 @@ const buttonVariants = cva(
         muted:
           "bg-muted text-muted-foreground shadow-xs hover:bg-muted/80",
         link: "text-primary underline-offset-4 hover:underline",
+        print: "border bg-transparent shadow-xs hover:bg-slate-300",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",

--- a/app/src/components/ui/toggle.tsx
+++ b/app/src/components/ui/toggle.tsx
@@ -5,13 +5,15 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const toggleVariants = cva(
-  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap cursor-pointer",
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap cursor-pointer",
   {
     variants: {
       variant: {
-        default: "bg-transparent",
+        default: "bg-transparent hover:bg-muted hover:text-muted-foreground data-[state=on]:bg-accent data-[state=on]:text-accent-foreground",
         outline:
-          "border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground data-[state=on]:bg-accent data-[state=on]:text-accent-foreground",
+        print:
+          "border bg-transparent shadow-xs hover:bg-slate-300 data-[state=on]:bg-slate-500 data-[state=on]:text-slate-200",
       },
       size: {
         default: "h-9 px-2 min-w-9",

--- a/app/src/hooks/usePrintConfig.tsx
+++ b/app/src/hooks/usePrintConfig.tsx
@@ -1,0 +1,54 @@
+import { create } from 'zustand'
+import { createJSONStorage, persist } from 'zustand/middleware'
+
+interface PrintConfigState {
+  fontSize: number
+  increateFontSize: () => void
+  decreateFontSize: () => void
+  resetFontSize: () => void
+  showChords: boolean
+  toggleChords: () => void
+  showNumbers: boolean
+  toggleNumbers: () => void
+  compactMode: boolean
+  toggleCompactMode: () => void
+}
+
+export const usePrintConfig = create<PrintConfigState>()(
+  persist(
+    (set, get) => ({
+      fontSize: 16,
+      increateFontSize: () => {
+        const cur = get().fontSize;
+        return set({ fontSize: cur + 1 });
+      },
+      decreateFontSize: () => {
+        const cur = get().fontSize;
+        if (cur <= 2) return;
+        return set({ fontSize: cur - 1 });
+      },
+      resetFontSize: () => {
+        return set({ fontSize: 16 });
+      },
+      showChords: true,
+      toggleChords: () => {
+        return set({ showChords: !get().showChords });
+      },
+      showNumbers: true,
+      toggleNumbers: () => {
+        return set({ showNumbers: !get().showNumbers });
+      },
+      compactMode: true,
+      toggleCompactMode: () => {
+        return set({ compactMode: !get().compactMode });
+      },
+    }),
+    {
+      name: "printConfig",
+      partialize: (state: PrintConfigState) => ({
+        fontSize: state.fontSize,
+      }),
+      storage: createJSONStorage(() => localStorage),
+    }
+  )
+);

--- a/app/src/layouts/print.tsx
+++ b/app/src/layouts/print.tsx
@@ -1,0 +1,18 @@
+import {
+  Outlet,
+} from "react-router-dom";
+
+import ProtectedRoute from "@/components/protected-route";
+
+export default function PrintLayout() {
+
+  return (
+    <ProtectedRoute>
+      <div className="bg-white text-slate-900">
+        <div className="flex flex-col items-center min-h-screen">
+          <Outlet />
+        </div>
+      </div>
+    </ProtectedRoute>
+  );
+}

--- a/app/src/routes/app/songs/all.loader.tsx
+++ b/app/src/routes/app/songs/all.loader.tsx
@@ -1,0 +1,5 @@
+import { SongsService } from "@/services";
+
+export async function loader({ songsService }: { songsService: SongsService }) {
+  return await songsService.getAll();
+}

--- a/app/src/routes/app/songs/edit.tsx
+++ b/app/src/routes/app/songs/edit.tsx
@@ -3,12 +3,11 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form";
 
 import { ILanguage, ISongWithRole, isRoleHigherOrEqualThan, SupportedLanguage, supportedLanguagesMap } from "@/types";
-import { SongsService } from "@/services";
 import { useServices } from "@/hooks/services.provider";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Link, Params, useLoaderData, useNavigate } from "react-router-dom";
+import { Link, useLoaderData, useNavigate } from "react-router-dom";
 import ArrowPathIcon from "@heroicons/react/24/solid/ArrowPathIcon";
 import { useTranslation } from "react-i18next";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -17,6 +16,7 @@ import ChevronDownIcon from "@heroicons/react/24/solid/ChevronDownIcon";
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
 import CheckIcon from "@heroicons/react/24/solid/CheckIcon";
 import EyeIcon from "@heroicons/react/24/solid/EyeIcon";
+import PrinterIcon from "@heroicons/react/24/solid/PrinterIcon";
 import i18next, { TFunction } from "i18next";
 import EditSongParts, { SongEditMode } from "@/components/app/songs/edit-parts";
 import { SongSchema } from "@/types/schemas/song.schema";
@@ -26,10 +26,6 @@ import { useAuth } from "@/hooks/useAuth";
 import { SongPreview } from "@/components/app/songs/song-preview";
 import Preview from "@/components/icons/preview";
 import ControllerProvider from "@/hooks/controller.provider";
-
-export async function loader({ params, songsService }: { params: Params, songsService: SongsService }) {
-  return await songsService.getById(Number(params.id));
-}
 
 function LanguageAndIcon({ t, language }: { t: TFunction, language: ILanguage["value"] }) {
   const lang = supportedLanguagesMap.find((lang) => lang.value === language);
@@ -151,6 +147,15 @@ export default function EditSong({
               <EyeIcon className="size-3" />
             </Link>
           </Button>}
+          <Button
+            type="button"
+            size="sm"
+            title={t('actions.print')}
+            asChild={true}>
+            <Link to={`/app/songs/${data.id}/print`}>
+              <PrinterIcon className="size-3" />
+            </Link>
+          </Button>
           <ControllerProvider>
             <SongPreview getSong={() => form.getValues()}>
               <Button

--- a/app/src/routes/app/songs/index.tsx
+++ b/app/src/routes/app/songs/index.tsx
@@ -8,7 +8,6 @@ import { CopySongToOrganization } from "@/components/app/songs/copy-song-to-orga
 import { Button } from "@/components/ui/button";
 import { DataTable, fuzzyFilter, fuzzySort } from "@/components/ui/data-table";
 import { DataTableColumnHeader } from "@/components/ui/data-table/column-header";
-import { SongsService } from "@/services";
 import { useServices } from "@/hooks/services.provider";
 import { useTranslation } from "react-i18next";
 import { TFunction } from "i18next";
@@ -16,10 +15,6 @@ import { useEffect } from "react";
 import { useAuth } from "@/hooks/useAuth";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "@/components/ui/alert-dialog";
 import { toast } from "sonner";
-
-export async function loader({ songsService }: { songsService: SongsService }) {
-  return await songsService.getAll();
-}
 
 const buildColumns = (t: TFunction, organization: IOrganization | null, onDeleteSong: (songId: number) => void) => {
   const columns: ColumnDef<ISong>[] = [

--- a/app/src/routes/app/songs/print.tsx
+++ b/app/src/routes/app/songs/print.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useState } from "react";
+import { Link, useLoaderData } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { cn } from "@/lib/utils";
+import { ISongPart, ISongWithRole, isRoleHigherOrEqualThan } from "@/types";
+import { usePrintConfig } from "@/hooks/usePrintConfig";
+import { Button } from "@/components/ui/button";
+import { Toggle } from "@/components/ui/toggle";
+import EyeIcon from "@heroicons/react/24/solid/EyeIcon";
+import PencilIcon from "@heroicons/react/24/solid/PencilIcon";
+import PrinterIcon from "@heroicons/react/24/solid/PrinterIcon";
+import PlusIcon from "@heroicons/react/24/solid/PlusIcon";
+import MinusIcon from "@heroicons/react/24/solid/MinusIcon";
+import BoldIcon from "@heroicons/react/24/solid/BoldIcon";
+import NumberedListIcon from "@heroicons/react/24/solid/NumberedListIcon";
+import ArrowsPointingInIcon from "@heroicons/react/24/solid/ArrowsPointingInIcon";
+
+const isBlockEqual = (a: ISongPart, b: ISongPart) => {
+  return a.text === b.text && a.chords === b.chords;
+};
+
+export default function PrintSong() {
+
+  const { t } = useTranslation("songs");
+
+  const data = useLoaderData() as ISongWithRole;
+
+  const {
+    fontSize,
+    increateFontSize,
+    decreateFontSize,
+    resetFontSize,
+    showChords,
+    toggleChords,
+    showNumbers,
+    toggleNumbers,
+    compactMode,
+    toggleCompactMode,
+  } = usePrintConfig();
+
+  if (!data) {
+    throw new Error("Can't find song");
+  }
+
+  if (!isRoleHigherOrEqualThan(data.organization?.role, 'guest')) {
+    throw new Error(t('error.noPermission'));
+  }
+
+  let orgName: string | undefined = t("organizations.publicArchive");
+  if (data.organization) {
+    orgName = data.organization.name || t("organizations.defaultName");
+  }
+
+  const canEdit = isRoleHigherOrEqualThan(data.organization?.role, 'member');
+
+  const [compactedBlocks, setCompactedBlocks] = useState<ISongPart[]>([]);
+  const [sequence, setSequence] = useState<number[]>([]);
+  useEffect(() => {
+    if (!data || !data.blocks) return;
+
+    const simplifiedSequence: number[] = [];
+    const simplifiedBlocks: ISongPart[] = [];
+
+    for (let ix = 0; ix < (data.blocks.length ?? 0); ix++) {
+      const sourceBlock = data.blocks[ix] ?? { text: '', chords: '' } as ISongPart;
+      let added: boolean = false;
+      for (let jx = 0; jx < simplifiedBlocks.length; jx++) {
+        const comparisonBlock = simplifiedBlocks[jx];
+
+        if (isBlockEqual(sourceBlock, comparisonBlock)) {
+          simplifiedSequence.push(jx + 1);
+          added = true;
+          break;
+        }
+      }
+
+      if (!added) {
+        simplifiedSequence.push(ix + 1);
+        simplifiedBlocks.push(sourceBlock);
+      }
+    }
+
+    setSequence(simplifiedSequence);
+    setCompactedBlocks(simplifiedBlocks);
+  }, [data.blocks]);
+
+  const [showBlocks, setShowBlocks] = useState<ISongPart[]>([]);
+  useEffect(() => {
+    if (!data || !data.blocks) return;
+
+    if (compactMode) {
+      setShowBlocks(compactedBlocks);
+    } else {
+      setShowBlocks(data.blocks);
+    }
+  }, [data.blocks, compactedBlocks, compactMode]);
+
+  return (
+    <>
+      <div className="w-full bg-slate-200 print:hidden">
+        <div className="max-w-2xl mx-auto flex items-center px-2 py-3 gap-x-2">
+          <span className="text-sm">{t('input.organization')}:<br/><b>{orgName}</b></span>
+          <div className="buttons flex-1 flex justify-end items-center gap-x-2">
+            <Button
+              type="button"
+              variant="print"
+              size="sm"
+              title={t('actions.decreaseFont')}
+              onClick={decreateFontSize}>
+              <MinusIcon className="size-3" />
+            </Button>
+            <Button
+              type="button"
+              variant="print"
+              size="sm"
+              title={t('actions.resetFont')}
+              onClick={resetFontSize}>
+              <BoldIcon className="size-3" />
+            </Button>
+            <Button
+              type="button"
+              variant="print"
+              size="sm"
+              title={t('actions.increaseFont')}
+              onClick={increateFontSize}>
+              <PlusIcon className="size-3" />
+            </Button>
+            <div className="h-7 border-s-1 border-slate-400"></div>
+            <Toggle
+              variant="print"
+              size="sm"
+              pressed={showNumbers}
+              title={t('actions.numbers')}
+              onClick={toggleNumbers}>
+              <NumberedListIcon className="size-3" />
+            </Toggle>
+            <Toggle
+              variant="print"
+              size="sm"
+              pressed={compactMode}
+              title={t('actions.compact')}
+              onClick={toggleCompactMode}>
+              <ArrowsPointingInIcon className="size-3" />
+            </Toggle>
+            <Toggle variant="print" size="sm" pressed={showChords} onPressedChange={toggleChords} title={t('input.viewChords')}>{t('input.viewChords')}</Toggle>
+            <div className="h-7 border-s-1 border-slate-400"></div>
+            <Button
+              type="button"
+              variant="print"
+              size="sm"
+              title={t('actions.edit')}
+              asChild>
+              {canEdit ? (
+                <Link to={`/app/songs/${data.id}/edit`}>
+                  <PencilIcon className="size-3" />
+                </Link>
+              ) : (
+                <Link to={`/app/songs/${data.id}/view`}>
+                  <EyeIcon className="size-3" />
+                </Link>
+              )}
+            </Button>
+            <Button
+              type="button"
+              variant="print"
+              size="sm"
+              title={t('actions.print')}
+              onClick={() => window.print()}>
+              <PrinterIcon className="size-3" />
+            </Button>
+          </div>
+        </div>
+      </div>
+      <div className="w-2xl px-2 font-mono" style={{ fontSize: `${fontSize}px` }}>
+        <h1 className="font-bold" style={{ fontSize: '1.5em' }}>{data.title}</h1>
+        <h2 className="text-slate-600 mb-[.5em]" style={{ fontSize: '1.125em' }}>{data.artist}</h2>
+        <div className="relative space-y-[.75em] leading-[1.6em]" style={{ fontSize: '0.875em' }}>
+          {compactMode && showNumbers && <div className="absolute top-0 right-0 flex flex-col justify-start items-end">
+            <b>{t('print.sequence')}</b>
+            {sequence.map(item => (
+              <span className="border-t-1 border-slate-300 text-center min-w-[1em] my-[.2em] py-[.2em]">{item}</span>
+            ))}
+          </div>}
+          {showBlocks.map((block, ix) => {
+            const hasText = (block?.text?.trim() ?? '').length > 0;
+            const hasChords = (block?.chords?.trim() ?? '').length > 0;
+            return (
+              <div className="flex flex-row justify-stretch items-stretch" key={`chords-${ix}`}>
+                {showNumbers && (
+                  <div className="py-[.2em] min-w-[1em] flex-0 text-center">
+                    <p className="text-slate-600">{ix + 1}</p>
+                  </div>
+                )}
+                <div className={cn(
+                  'grid grid-cols-1 grid-rows-1 border-s-1 border-slate-300 ps-[.75em] py-[.2em] min-h-[.75em] text-slate-800',
+                  showNumbers && 'ms-[.75em]',
+                )}>
+                  {hasText && <p className="col-start-1 row-start-1 whitespace-pre">{showChords && hasChords ? block.text?.split(/\n/).map(l => '\n' + l).join('\n') : block.text}</p>}
+                  {showChords && hasChords && <p className="col-start-1 row-start-1 whitespace-pre font-bold">{hasText ? block.chords?.split(/\n/).map(l => l + '\n').join('\n') : block.chords}</p>}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/src/routes/app/songs/single.loader.tsx
+++ b/app/src/routes/app/songs/single.loader.tsx
@@ -1,0 +1,6 @@
+import { SongsService } from "@/services";
+import { Params } from "react-router-dom";
+
+export async function loader({ params, songsService }: { params: Params, songsService: SongsService }) {
+  return await songsService.getById(Number(params.id));
+}

--- a/app/src/routes/router.tsx
+++ b/app/src/routes/router.tsx
@@ -11,6 +11,7 @@ import { loader as authLoader } from "@/layouts/auth.loader"
 import AppLayout from "@/layouts/app";
 import ErrorLayout from "@/layouts/error";
 import ControllerLayout from "@/layouts/controller";
+import PrintLayout from "@/layouts/print";
 import { useServices, ServicesProviderState } from "@/hooks/services.provider";
 
 import Home from "./home";
@@ -25,9 +26,12 @@ import Discover from "./app/discover";
 import Profile from "./app/profile";
 import { loader as profileLoader } from "./app/profile.loader";
 
-import SongsIndex, { loader as indexSongLoader } from "./app/songs/index";
-import EditSong, { loader as editSongLoader } from "./app/songs/edit";
-import ViewSong, { loader as viewSongLoader } from "./app/songs/view";
+import SongsIndex from "./app/songs/index";
+import EditSong from "./app/songs/edit";
+import ViewSong from "./app/songs/view";
+import PrintSong from "./app/songs/print";
+import { loader as singleSongLoader } from "./app/songs/single.loader";
+import { loader as allSongsLoader } from "./app/songs/all.loader";
 
 import EditOrganization from "./app/organizations/index";
 import { loader as editOrganizationLoader } from "./app/organizations/index.loader"
@@ -52,10 +56,10 @@ export const buildRouter = (services: ServicesProviderState) => {
           <Route index={true} element={<Welcome />} loader={() => welcomeLoader({ organizationsService: services.organizationsService })} />
           <Route path="profile" element={<Profile />} loader={() => profileLoader({ usersService: services.usersService })} />
           <Route path="songs">
-            <Route index={true} element={<SongsIndex />} loader={() => indexSongLoader({ songsService: services.songsService })} />
+            <Route index={true} element={<SongsIndex />} loader={() => allSongsLoader({ songsService: services.songsService })} />
             <Route path="add" element={<EditSong edit={false} />} />
-            <Route path=":id/view" element={<ViewSong />} loader={(loader: LoaderFunctionArgs) => viewSongLoader({ params: loader.params, songsService: services.songsService })} />
-            <Route path=":id/edit" element={<EditSong />} loader={(loader: LoaderFunctionArgs) => editSongLoader({ params: loader.params, songsService: services.songsService })} />
+            <Route path=":id/view" element={<ViewSong />} loader={(loader: LoaderFunctionArgs) => singleSongLoader({ params: loader.params, songsService: services.songsService })} />
+            <Route path=":id/edit" element={<EditSong />} loader={(loader: LoaderFunctionArgs) => singleSongLoader({ params: loader.params, songsService: services.songsService })} />
           </Route>
           <Route path="discover" element={<Discover />} />
           <Route path="organization">
@@ -67,6 +71,9 @@ export const buildRouter = (services: ServicesProviderState) => {
           <Route path="organizations">
             <Route path="add" element={<EditOrganization edit={false} />} />
           </Route>
+        </Route>
+        <Route path="/app" element={<PrintLayout />} errorElement={<ErrorLayout />}>
+          <Route path="songs/:id/print" element={<PrintSong />} loader={(loader: LoaderFunctionArgs) => singleSongLoader({ params: loader.params, songsService: services.songsService })} />
         </Route>
         <Route path="/app/controller" element={<ControllerLayout />} errorElement={<ErrorLayout />}>
           <Route index={true} element={<Controller />} />

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -81,6 +81,10 @@ module.exports = {
       fontFamily: {
         mono: ['Source Code Pro', 'ui-monospace', 'monospace'],
       },
+      screens: {
+        print: { raw: 'print' },
+        screen: { raw: 'screen' },
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
Task: #10 

- Add "Print" buttons for songs in both View and Edit modes
- Add `/print` route for song, which shows songs in a plain B&W layout
- Added multiple formatting options for printing (font size, numbering, sequence, compact mode)

Unrelated:

- Move song loader to prevent code duplication
- Fix bug that wouldn't update Song lyrics when switching to Chords mode