### PR TITLE
[Bugfix]: Ensure blocks are being returned, fix issue when no screenDetails

### DIFF
--- a/.github/workflows/api-build-and-deploy.yml
+++ b/.github/workflows/api-build-and-deploy.yml
@@ -37,5 +37,7 @@ jobs:
 
     - name: Redeploy Lightsail with latest image
       run: |
-        CONTAINERS=::add-mask::$(aws lightsail get-container-service-deployments --service-name "blu-presenter-api" --query 'deployments[0].containers' --output json)
+        set +x
+        CONTAINERS=$(aws lightsail get-container-service-deployments --service-name 'blu-presenter-api' --query 'deployments[0].containers' --output json)
         aws lightsail create-container-service-deployment --service-name "blu-presenter-api" --containers "$CONTAINERS"
+        set -x

--- a/api/src/types/advanced-search.dto.ts
+++ b/api/src/types/advanced-search.dto.ts
@@ -20,4 +20,7 @@ export class AdvancedSearchDto {
 
   @IsBoolean()
   searchPublicArchive?: boolean;
+
+  @IsBoolean()
+  includeBlocks?: boolean;
 }

--- a/app/src/components/app/search/advanced-search-form.tsx
+++ b/app/src/components/app/search/advanced-search-form.tsx
@@ -22,7 +22,13 @@ const advancedSearchFormSchema = z.object({
   searchPublicArchive: z.boolean(),
 });
 
-export function AdvancedSearchForm() {
+interface AdvancedSearchFormProps {
+  includeBlocks?: boolean;
+}
+
+export function AdvancedSearchForm({
+  includeBlocks = false,
+}: AdvancedSearchFormProps) {
 
   const { t } = useTranslation('discover');
   const {
@@ -48,6 +54,7 @@ export function AdvancedSearchForm() {
       languages: values.languages as SupportedLanguage[],
       organizations: values.organizations?.length === organizations.length ? undefined : (values.organizations?.map(x => parseInt(x)) || []),
       searchPublicArchive: values.searchPublicArchive,
+      includeBlocks,
     })
       .catch((e) => {
         toast.error(t('errors.search'), {

--- a/app/src/components/app/search/basic-search-form.tsx
+++ b/app/src/components/app/search/basic-search-form.tsx
@@ -12,7 +12,13 @@ const basicSearchFormSchema = z.object({
   query: z.string().min(3),
 });
 
-export function BasicSearchForm() {
+interface BasicSearchFormProps {
+  includeBlocks?: boolean;
+}
+
+export function BasicSearchForm({
+  includeBlocks = false,
+}: BasicSearchFormProps) {
 
   const { t } = useTranslation('discover');
   const {
@@ -28,7 +34,7 @@ export function BasicSearchForm() {
   });
 
   const onSubmit = async (values: z.infer<typeof basicSearchFormSchema>) => {
-    await search(values.query);
+    await search(values.query, includeBlocks);
   }
 
   return (

--- a/app/src/components/controller/plan-search.tsx
+++ b/app/src/components/controller/plan-search.tsx
@@ -56,10 +56,10 @@ export function PlanSearch() {
           <TabsTrigger value="advanced">{t('plan.search.advanced')}</TabsTrigger>
         </TabsList>
         <TabsContent value="basic">
-          <BasicSearchForm />
+          <BasicSearchForm includeBlocks={true} />
         </TabsContent>
         <TabsContent value="advanced">
-          <AdvancedSearchForm />
+          <AdvancedSearchForm includeBlocks={true} />
         </TabsContent>
       </Tabs>
       <div

--- a/app/src/components/controller/preview-window.tsx
+++ b/app/src/components/controller/preview-window.tsx
@@ -84,7 +84,8 @@ export function PreviewWindow({
 
   useEffect(() => {
     const browserWindow = window as unknown as IBrowserWindow;
-    const screenDetailsPromise = browserWindow.getScreenDetails();
+    if (!browserWindow?.getScreenDetails) return;
+    const screenDetailsPromise = browserWindow?.getScreenDetails();
     if (screenDetailsPromise) {
       screenDetailsPromise.then((details: { screens: IScreenDetails[] }) => {
         const screenRatioOptions = details.screens.map((s, ix: number) => {

--- a/app/src/components/controller/screen-selector.tsx
+++ b/app/src/components/controller/screen-selector.tsx
@@ -37,15 +37,17 @@ export default function ScreenSelector({ children }: { children: ReactNode }) {
     const browserWindow = childWindow as unknown as IBrowserWindow;
     const browserScreen = browserWindow?.screen || browserWindow?.currentScreen;
 
-    if (browserScreen?.isExtended == true || browserWindow?.screens?.length > 1) {
-      const screenDetailsPromise = browserWindow?.getScreenDetails();
-      if (screenDetailsPromise) {
-        screenDetailsPromise.then((details: {screens: IScreenDetails[]}) => {
-          setDisplayOptions(details.screens);
-        });
-      }
-    } else {
+    if (!browserScreen || !(browserScreen?.isExtended) || !((browserWindow?.screens?.length ?? 1) > 1)) {
       setSelected(true);
+      return;
+    }
+
+    if (!browserWindow?.getScreenDetails) return;
+    const screenDetailsPromise = browserWindow?.getScreenDetails();
+    if (screenDetailsPromise) {
+      screenDetailsPromise.then((details: {screens: IScreenDetails[]}) => {
+        setDisplayOptions(details.screens);
+      });
     }
   }, []);
 

--- a/app/src/services/songs.service.ts
+++ b/app/src/services/songs.service.ts
@@ -31,6 +31,7 @@ export class SongsService extends ApiService {
       organizations?: number[];
       languages?: string[] | undefined;
       searchPublicArchive?: boolean;
+      includeBlocks?: boolean;
     }
   ): Promise<ISongWithRole[]> {
     return await this.postRequest('/songs/advancedSearch', JSON.stringify(payload), {


### PR DESCRIPTION
Bugfixes:
- Fix `blocks` not being returned on Controller
- Fix UI issue when browser doesn't support `getScreenDetails()`
- Test disabling logs on API deployment