### PR TITLE
[Feature]: Shareable schedule

### DIFF
--- a/api/src/schedules/schedules.controller.ts
+++ b/api/src/schedules/schedules.controller.ts
@@ -7,11 +7,13 @@ import {
   Param,
   Post,
   Put,
+  Query,
 } from '@nestjs/common';
 import { Schedule } from 'src/entities';
 import { CreateScheduleDto, UpdateScheduleDto } from 'src/types';
 import { SchedulesService } from './schedules.service';
 import { OrganizationRole } from 'src/auth/organization-role.decorator';
+import { Public } from 'src/supabase/public.decorator';
 
 @Controller('schedules')
 export class SchedulesController {
@@ -23,13 +25,13 @@ export class SchedulesController {
     return await this.schedulesService.findAll(orgId);
   }
 
+  @Public()
   @Get(':id')
-  @OrganizationRole('owner', 'admin', 'member', 'guest')
   async findOne(
-    @Headers('Organization') orgId: number,
     @Param('id') id: number,
+    @Query('secret') secret?: string,
   ): Promise<Schedule | null> {
-    return await this.schedulesService.findOne(orgId, id);
+    return await this.schedulesService.findOneInAnyOrgOrBySecret(id, secret);
   }
 
   @Post()

--- a/api/src/schedules/schedules.module.ts
+++ b/api/src/schedules/schedules.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Schedule, Song } from '../entities';
 import { SchedulesController } from './schedules.controller';
 import { SchedulesService } from './schedules.service';
+import { UsersModule } from 'src/users/users.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Schedule, Song])],
+  imports: [TypeOrmModule.forFeature([Schedule, Song]), UsersModule],
   controllers: [SchedulesController],
   providers: [SchedulesService],
 })

--- a/api/src/schedules/schedules.service.ts
+++ b/api/src/schedules/schedules.service.ts
@@ -7,12 +7,21 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
-import { CreateScheduleDto, IScheduleItem, UpdateScheduleDto } from 'src/types';
+import { In, IsNull, Or, Repository } from 'typeorm';
+import { CreateScheduleDto, IScheduleItem, OrganizationRoleOptions, UpdateScheduleDto } from 'src/types';
 import { Schedule, Song } from 'src/entities';
 import { REQUEST } from '@nestjs/core';
 import { Request as ExpRequest } from 'express';
 import { generateRandomSecret } from 'src/utils/secret';
+import { UsersService } from 'src/users/users.service';
+
+type ScheduleWithRole = Schedule & {
+  organization?: {
+    id: number;
+    name: string;
+    role?: OrganizationRoleOptions;
+  };
+};
 
 @Injectable({ scope: Scope.REQUEST })
 export class SchedulesService {
@@ -21,6 +30,8 @@ export class SchedulesService {
     private readonly schedulesRepository: Repository<Schedule>,
     @InjectRepository(Song)
     private readonly songsRepository: Repository<Song>,
+    @Inject(UsersService)
+    private readonly usersService: UsersService,
     @Inject(REQUEST) private readonly request: ExpRequest,
   ) {}
 
@@ -71,6 +82,69 @@ export class SchedulesService {
 
     schedule.items = await this.resolveSongReferences(schedule.items);
     return schedule;
+  }
+
+  async findOneInAnyOrgOrBySecret(id: number, secret?: string): Promise<ScheduleWithRole | null> {
+    let whereClause: any = { id };
+
+    let userOrgs: any[] = [];
+    let userOrgIds: number[] = [];
+
+    if (!!this.request.user) {
+      const user = this.request.user['internal'];
+      userOrgs = await this.usersService.findUserOrganizations(user.id);
+      userOrgIds = userOrgs.map((org) => org.organization.id);
+
+      whereClause.orgId = Or(In(userOrgIds), IsNull());
+
+      if (secret) {
+        whereClause = [whereClause, { id, secret }];
+      }
+    } else {
+      whereClause.secret = secret ?? IsNull();
+    }
+
+    const schedule = await this.schedulesRepository.findOne({
+      select: {
+        id: true,
+        orgId: true,
+        title: true,
+        date: true,
+        items: true,
+        secret: true,
+        organization: {
+          id: true,
+          name: true,
+        },
+      },
+      where: whereClause,
+      relations: {
+        organization: true,
+      },
+    });
+
+    if (!schedule) {
+      return null;
+    }
+
+    if (schedule.items?.length) {
+      schedule.items = await this.resolveSongReferences(schedule.items);
+    }
+
+    const orgUser = userOrgs.find((org) => org.organization.id === schedule.orgId);
+
+    return {
+      ...schedule,
+      organization: orgUser
+        ? {
+            ...orgUser.organization,
+            role: orgUser.role as OrganizationRoleOptions,
+          }
+        : {
+            ...schedule.organization,
+            role: undefined,
+          },
+    } as ScheduleWithRole;
   }
 
   private async resolveSongReferences(items: IScheduleItem[]): Promise<IScheduleItem[]> {

--- a/api/src/schedules/schedules.service.ts
+++ b/api/src/schedules/schedules.service.ts
@@ -165,6 +165,7 @@ export class SchedulesService {
         'song.blocks',
         'song.references',
         'song.secret',
+        'song.updatedAt',
       ])
       .where('song.id IN (:...songIds)', { songIds })
       .getMany();
@@ -190,6 +191,7 @@ export class SchedulesService {
           blocks: song.blocks,
           references: song.references,
           secret: song.secret,
+          updatedAt: song.updatedAt,
         };
       })
       .filter((item) => item !== null);

--- a/api/src/songs/songs.service.ts
+++ b/api/src/songs/songs.service.ts
@@ -77,6 +77,9 @@ export class SongsService {
         },
       },
       where: whereClause,
+      relations: {
+        organization: true,
+      },
     });
 
     if (!song) {

--- a/api/src/types/schedule-item.interface.ts
+++ b/api/src/types/schedule-item.interface.ts
@@ -10,4 +10,5 @@ export interface IScheduleItem {
   slides?: any[]
   secret?: string
   uniqueId?: number
+  updatedAt?: Date
 }

--- a/app/locales/en/schedules.json
+++ b/app/locales/en/schedules.json
@@ -2,10 +2,13 @@
   "title": {
     "list": "Schedules - {{organization}}",
     "add": "Add - Schedules",
-    "edit": "{{name}} - Schedules"
+    "edit": "{{name}} - Schedules",
+    "view": "{{name}} - View - Schedules"
   },
   "actions": {
     "create": "Add schedule",
+    "view": "View schedule",
+    "share": "Share",
     "edit": "Edit schedule",
     "delete": "Delete schedule",
     "addItem": "Add item"
@@ -14,7 +17,8 @@
     "add": "Add",
     "update": "Update",
     "cancel": "Cancel",
-    "confirm": "Confirm"
+    "confirm": "Confirm",
+    "back": "Back"
   },
   "input": {
     "organization": "Organization",
@@ -30,6 +34,18 @@
   "edit": {
     "title": "Edit schedule"
   },
+  "view": {
+    "untitled": "Untitled",
+    "type": {
+      "song": "Song",
+      "text": "Text",
+      "comment": "Comment"
+    },
+    "chords": {
+      "available": "Chords available",
+      "notAvailable": "No chords available"
+    }
+  },
   "column": {
     "title": "Title",
     "date": "Date"
@@ -42,6 +58,10 @@
     "noPermission": "You don't have permission to manage schedules"
   },
   "message": {
+    "share": {
+      "title": "Link copied",
+      "description": "A shareable link to the schedule has been copied to the clipboard."
+    },
     "deleteSchedule": {
       "title": "Delete schedule",
       "description": "Are you sure you want to delete the schedule \"{{name}}\"? This action cannot be undone."

--- a/app/locales/pt/schedules.json
+++ b/app/locales/pt/schedules.json
@@ -2,10 +2,13 @@
   "title": {
     "list": "Programações - {{organization}}",
     "add": "Adicionar - Programações",
-    "edit": "{{name}} - Programações"
+    "edit": "{{name}} - Programações",
+    "view": "{{name}} - Visualizar - Programações"
   },
   "actions": {
     "create": "Adicionar programação",
+    "view": "Visualizar programação",
+    "share": "Compartilhar",
     "edit": "Editar programação",
     "delete": "Remover programação",
     "addItem": "Adicionar item"
@@ -14,7 +17,8 @@
     "add": "Adicionar",
     "update": "Atualizar",
     "cancel": "Cancelar",
-    "confirm": "Confirmar"
+    "confirm": "Confirmar",
+    "back": "Voltar"
   },
   "input": {
     "organization": "Organização",
@@ -30,6 +34,18 @@
   "edit": {
     "title": "Editar programação"
   },
+  "view": {
+    "untitled": "Sem título",
+    "type": {
+      "song": "Música",
+      "text": "Texto",
+      "comment": "Comentário"
+    },
+    "chords": {
+      "available": "Cifras disponíveis",
+      "notAvailable": "Sem cifras disponíveis"
+    }
+  },
   "column": {
     "title": "Título",
     "date": "Data"
@@ -42,6 +58,10 @@
     "noPermission": "Você não tem permissão para gerenciar programações"
   },
   "message": {
+    "share": {
+      "title": "Link copiado",
+      "description": "Um link compartilhável para a programação foi copiado para a área de transferência."
+    },
     "deleteSchedule": {
       "title": "Remover programação",
       "description": "Tem certeza que deseja remover a programação \"{{name}}\"? Esta ação não pode ser desfeita."

--- a/app/src/components/controller/plan-schedules.tsx
+++ b/app/src/components/controller/plan-schedules.tsx
@@ -82,7 +82,7 @@ export function PlanSchedules() {
   }, [filtered, todayString]);
 
   const handleLoad = async (scheduleId: number) => {
-    const fullSchedule = await schedulesService.getById(scheduleId);
+    const fullSchedule = await schedulesService.fetchById(scheduleId);
     if (fullSchedule?.items) {
       replaceSchedule(songsService.resolveScheduleItems(fullSchedule.items));
     }

--- a/app/src/components/controller/preview-window.tsx
+++ b/app/src/components/controller/preview-window.tsx
@@ -10,6 +10,7 @@ import { ITheme, LyricsTheme, SubtitlesTheme, TeleprompterTheme } from "@/types"
 import { IBrowserWindow, IScreenDetails } from "@/types/browser";
 import { useController } from "@/hooks/useController";
 import { useServices } from "@/hooks/useServices";
+import { usePreviewConfig } from "@/hooks/usePreviewConfig";
 
 const defaultThemeOptions = [
   {
@@ -53,10 +54,17 @@ export function PreviewWindow({
 
   const { t } = useTranslation('controller');
 
+  const {
+    previewTheme: storedTheme,
+    previewRatio: storedRatio,
+    setPreviewTheme: storeSetPreviewTheme,
+    setPreviewRatio: storeSetPreviewRatio,
+  } = usePreviewConfig();
+
   const [openPreviewThemeSelector, setOpenPreviewThemeSelector] = useState<boolean>(false);
-  const [previewTheme, setPreviewTheme] = useState<ITheme>(theme);
+  const [previewTheme, setPreviewTheme] = useState<ITheme>(showThemeSelector ? storedTheme : theme);
   const [openPreviewRatioSelector, setOpenPreviewRatioSelector] = useState<boolean>(false);
-  const [previewRatio, setPreviewRatio] = useState<string>("16/9");
+  const [previewRatio, setPreviewRatio] = useState<string>(storedRatio);
   const [ratioOptions, setRatioOptions] = useState<{ value: string, label: string }[]>(defaultRatioOptions);
 
   const {
@@ -71,6 +79,10 @@ export function PreviewWindow({
   const updatePreviewTheme = (theme: ITheme) => {
     setPreviewTheme(theme);
 
+    if (showThemeSelector) {
+      storeSetPreviewTheme(theme);
+    }
+
     if (attachControllerMode && mode !== 'part') {
       const newMode = theme.extends === 'subtitles' ? 'part': 'slide';
       setMode(newMode);
@@ -80,6 +92,7 @@ export function PreviewWindow({
     if (ratio === previewRatio) return;
 
     setPreviewRatio(ratio);
+    storeSetPreviewRatio(ratio);
   }
 
   useEffect(() => {

--- a/app/src/components/controller/preview-window.tsx
+++ b/app/src/components/controller/preview-window.tsx
@@ -125,7 +125,9 @@ export function PreviewWindow({
   }, []);
 
   useEffect(() => {
-    updatePreviewTheme(theme);
+    if (!showThemeSelector) {
+      updatePreviewTheme(theme);
+    }
   }, [theme]);
 
   const [consolidatedOptions, setConsolidatedOptions] = useState<typeof defaultThemeOptions>(defaultThemeOptions);

--- a/app/src/components/controller/schedule-item.tsx
+++ b/app/src/components/controller/schedule-item.tsx
@@ -47,7 +47,7 @@ export function ScheduleItem({
   const text = item as IScheduleText;
 
   return (
-    <Card variant={item.type === 'comment' ? 'secondary' : 'default'} className="mt-3">
+    <Card variant={item.type === 'comment' ? 'secondary' : 'default'} className="mt-3 animate-in fade-in-0 slide-in-from-top-2 duration-300">
       <Collapsible
         open={isExpanded}
         onOpenChange={setExpanded}

--- a/app/src/components/controller/schedule-panel.tsx
+++ b/app/src/components/controller/schedule-panel.tsx
@@ -85,7 +85,7 @@ export function SchedulePanel({ showRestore = true, showOpen = true }: ScheduleP
             <div id="schedule-items" className="flex-1">
             {(schedule as ISortableScheduleItem[]).map((item, ix) => (
               <SortableItem
-                key={`schedule[${ix}]`}
+                key={item.uniqueId ?? item.id}
                 value={item.uniqueId ?? item.id}
                 asChild>
                 <div key={item.uniqueId ?? item.id}>

--- a/app/src/hooks/controller.provider.tsx
+++ b/app/src/hooks/controller.provider.tsx
@@ -4,6 +4,7 @@ import { Key } from 'ts-key-enum';
 
 import { SelectorScreen } from "@/components/controller/selector-screen"
 import { IScheduleItem, IWindow, ISlide, ControllerMode, ISlideTextContent, ISlideImageContent, IControllerSelection } from "@/types"
+import { generateScheduleItemUniqueId } from "@/lib/utils"
 import { WindowProvider } from "./window.provider"
 
 export interface IControllerConfig {
@@ -127,18 +128,22 @@ export function ControllerProvider({
   const addToSchedule = (item: IScheduleItem | IScheduleItem[]) => {
     const items = Array.isArray(item) ? item : [item];
 
-    const uniqueIdBase = Date.now();
     const startingIx = schedule.length;
     const newValue = [
       ...schedule,
-      ...items.map((item, ix) => ({ ...item, index: startingIx + ix, uniqueId: uniqueIdBase + ix })),
+      ...items.map((item, ix) => {
+        const uniqueId = generateScheduleItemUniqueId(item, startingIx + ix);
+        return { ...item, index: startingIx + ix, uniqueId };
+      }),
     ];
     saveAndSetSchedule(newValue);
   };
   const replaceSchedule = (items: IScheduleItem[]) => {
-    const uniqueIdBase = Date.now();
     const newValue = [
-      ...items.map((item, ix) => ({ ...item, index: ix, uniqueId: uniqueIdBase + ix })),
+      ...items.map((item, ix) => {
+        const uniqueId = generateScheduleItemUniqueId(item, ix);
+        return { ...item, index: ix, uniqueId };
+      }),
     ];
     saveAndSetSchedule(newValue);
   };

--- a/app/src/hooks/usePreviewConfig.tsx
+++ b/app/src/hooks/usePreviewConfig.tsx
@@ -1,0 +1,29 @@
+import { create } from 'zustand'
+import { createJSONStorage, persist } from 'zustand/middleware'
+import { ITheme, LyricsTheme } from '@/types'
+
+interface PreviewConfigState {
+  previewTheme: ITheme
+  previewRatio: string
+  setPreviewTheme: (theme: ITheme) => void
+  setPreviewRatio: (ratio: string) => void
+}
+
+export const usePreviewConfig = create<PreviewConfigState>()(
+  persist(
+    (set) => ({
+      previewTheme: LyricsTheme,
+      previewRatio: '16/9',
+      setPreviewTheme: (theme: ITheme) => set({ previewTheme: theme }),
+      setPreviewRatio: (ratio: string) => set({ previewRatio: ratio }),
+    }),
+    {
+      name: 'previewConfig',
+      partialize: (state: PreviewConfigState) => ({
+        previewTheme: state.previewTheme,
+        previewRatio: state.previewRatio,
+      }),
+      storage: createJSONStorage(() => localStorage),
+    }
+  )
+);

--- a/app/src/lib/utils.ts
+++ b/app/src/lib/utils.ts
@@ -1,5 +1,8 @@
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
+import { IScheduleItem } from "@/types/schedule-item.interface"
+import { IScheduleSong } from "@/types/schedule-song.interface"
+import { IScheduleText } from "@/types/schedule-text.interface"
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -14,4 +17,37 @@ export function isTokenExpired(token: string | undefined | null): boolean {
   } catch {
     return true;
   }
+}
+
+/**
+ * djb2-style hash: fast, deterministic, no external dependencies.
+ * Returns a hex string for use in IDs.
+ */
+function hashString(str: string): string {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = (hash * 33) ^ str.charCodeAt(i);
+  }
+  // Convert to unsigned 32-bit and then hex
+  return (hash >>> 0).toString(16);
+}
+
+/**
+ * Generates a stable uniqueId for a schedule item at the given index.
+ *
+ * - Songs: `<id>_<updatedAt>_<index>` — stable as long as the song and its
+ *   position in the schedule do not change.
+ * - Non-song items (text, comment, …): `hash(<title><subtitle>)_<index>` —
+ *   content-derived so the ID survives page reloads without relying on
+ *   wall-clock time.
+ */
+export function generateScheduleItemUniqueId(item: IScheduleItem, index: number): string {
+  if (item.type === 'song') {
+    const song = item as IScheduleSong;
+    return `${song.id}_${song.updatedAt ?? ''}_${index}`;
+  }
+
+  const text = item as IScheduleText;
+  const content = `${text.title ?? ''}|${text.subtitle ?? ''}`;
+  return `${hashString(content)}_${index}`;
 }

--- a/app/src/routes/app/schedules/edit.tsx
+++ b/app/src/routes/app/schedules/edit.tsx
@@ -20,6 +20,7 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import ArrowPathIcon from "@heroicons/react/24/solid/ArrowPathIcon";
 import PlusIcon from "@heroicons/react/24/solid/PlusIcon";
+import EyeIcon from "@heroicons/react/24/solid/EyeIcon";
 
 type EditScheduleProps = {
   edit?: boolean
@@ -66,6 +67,19 @@ export function EditSchedule({
       <title>{(edit ? t('title.edit', { name: data.title }) : t('title.add')) + ' - ' + orgName + ' - BluPresenter'}</title>
       <div className="flex items-center px-2 sm:px-8 py-3 bg-slate-200 dark:bg-slate-900 gap-x-2">
         <span className="text-sm">{t('input.organization')}: <b>{orgName}</b></span>
+        <div className="buttons flex-1 flex justify-end gap-x-2">
+          {edit && (
+            <Button
+              type="button"
+              size="sm"
+              title={t('actions.view')}
+              asChild>
+              <Link to={`/app/schedules/${data.id}/view`}>
+                <EyeIcon className="size-3" />
+              </Link>
+            </Button>
+          )}
+        </div>
       </div>
       <div className="p-2 sm:p-8 flex flex-col flex-1 overflow-hidden">
         <h1 className="text-3xl mb-4">{edit ? t('edit.title') : t('add.title')}</h1>

--- a/app/src/routes/app/schedules/edit.tsx
+++ b/app/src/routes/app/schedules/edit.tsx
@@ -159,8 +159,8 @@ function EditScheduleForm({
       action = schedulesService.add(payload);
     }
     action
-      .then(() => {
-        navigate(`/app/schedules`);
+      .then((savedSchedule: ISchedule | null) => {
+        navigate(`/app/schedules/${savedSchedule?.id}/view`);
       })
       .catch((err) => {
         console.error(err);

--- a/app/src/routes/app/schedules/index.tsx
+++ b/app/src/routes/app/schedules/index.tsx
@@ -3,6 +3,7 @@ import { ColumnDef } from "@tanstack/react-table"
 import { format, parse } from "date-fns";
 import PencilIcon from "@heroicons/react/24/solid/PencilIcon";
 import TrashIcon from "@heroicons/react/24/solid/TrashIcon";
+import EyeIcon from "@heroicons/react/24/solid/EyeIcon";
 import { IOrganization, ISchedule, isRoleHigherOrEqualThan } from "@/types";
 import { Button } from "@/components/ui/button";
 import { getLocaleConfig } from "@/components/ui/date-picker";
@@ -48,6 +49,15 @@ const buildColumns = (t: TFunction, lang: string, organization: IOrganization | 
       cell: ({ row }) => {
         return (
           <div className="flex justify-end space-x-2 -m-1">
+            <Button
+              type="button"
+              size="sm"
+              title={t('actions.view')}
+              asChild>
+              <Link to={`/app/schedules/${row.original.id}/view`}>
+                <EyeIcon className="size-3" />
+              </Link>
+            </Button>
             <Button
               type="button"
               size="sm"

--- a/app/src/routes/app/schedules/single.loader.tsx
+++ b/app/src/routes/app/schedules/single.loader.tsx
@@ -1,6 +1,6 @@
 import { SchedulesService } from "@/services";
 import { Params } from "react-router-dom";
 
-export async function loader({ params, schedulesService }: { params: Params, schedulesService: SchedulesService }) {
-  return await schedulesService.getById(Number(params.id));
+export async function loader({ params, schedulesService, secret }: { params: Params, schedulesService: SchedulesService, secret?: string }) {
+  return await schedulesService.getById(Number(params.id), secret);
 }

--- a/app/src/routes/app/schedules/view.tsx
+++ b/app/src/routes/app/schedules/view.tsx
@@ -1,0 +1,143 @@
+import { Card, CardDescription, CardHeader, CardHeaderActions, CardHeaderText, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ISchedule, IScheduleItem, IScheduleSong, IScheduleText } from "@/types";
+import EyeIcon from "@heroicons/react/24/solid/EyeIcon";
+import MusicalNoteIcon from "@heroicons/react/24/solid/MusicalNoteIcon";
+import PencilIcon from "@heroicons/react/24/solid/PencilIcon";
+import ShareIcon from "@heroicons/react/24/solid/ShareIcon";
+import { parse, format } from "date-fns";
+import { Link, useLoaderData, useParams } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { getLocaleConfig } from "@/components/ui/date-picker";
+import { useAuth } from "@/hooks/useAuth";
+import { toast } from "sonner";
+
+export function ViewSchedule() {
+  const { t, i18n } = useTranslation("schedules");
+  const { isLoggedIn } = useAuth();
+  const params = useParams();
+  const data = useLoaderData() as ISchedule | null;
+
+  if (!data) {
+    throw new Error("Can't find schedule");
+  }
+
+  const lang = i18n.language?.substring(0, 2) ?? "en";
+  const { dateFns, formatStr } = getLocaleConfig(lang);
+
+  let formattedDate = "";
+  if (data.date) {
+    const parsed = parse(data.date, "yyyy-MM-dd", new Date());
+    formattedDate = format(parsed, formatStr, { locale: dateFns });
+  }
+
+  const getSongLink = (item: IScheduleItem): string | null => {
+    if (item.type !== "song") {
+      return null;
+    }
+
+    const songItem = item as IScheduleSong;
+    if (!params.secret) {
+      return `/app/songs/${songItem.id}/view`;
+    }
+
+    let songUrl = `/shared/view/${songItem.id}/`;
+    if (songItem.secret) {
+      songUrl += songItem.secret;
+    }
+
+    return songUrl;
+  };
+
+  const copyShareableUrlToClipboard = async () => {
+    const currentUrl = new URL(window.location.href);
+    const shareUrl = `${currentUrl.protocol}//${currentUrl.host}/shared/schedules/${data.id}/${data.secret ?? ''}`;
+    const clipboard = navigator.clipboard;
+    if (!!clipboard) {
+      await navigator.clipboard.writeText(shareUrl);
+      toast.success(t('message.share.title'), {
+        description: t('message.share.description'),
+      });
+    } else {
+      window.open(shareUrl, '_blank');
+    }
+  };
+
+  return (
+    <>
+      <title>{t("title.view", { name: data.title }) + " - BluPresenter"}</title>
+      <div className="flex items-center px-2 sm:px-8 py-3 bg-slate-200 dark:bg-slate-900 gap-x-2">
+        <span className="text-sm">{t("list.title")}</span>
+        <div className="buttons flex-1 flex justify-end gap-x-2">
+          <Button
+            type="button"
+            size="sm"
+            title={t("actions.share")}
+            onClick={copyShareableUrlToClipboard}>
+            <ShareIcon className="size-3" />
+          </Button>
+          {isLoggedIn && (
+            <Button type="button" size="sm" title={t("actions.edit")} asChild>
+              <Link to={`/app/schedules/${data.id}/edit`}>
+                <PencilIcon className="size-3" />
+              </Link>
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="p-2 sm:p-8 max-w-3xl">
+        <h1 className="text-3xl mb-2">{data.title}</h1>
+        {formattedDate && <h2 className="text-lg mb-4 opacity-50">{formattedDate}</h2>}
+
+        <div className="space-y-3">
+          {data.items?.map((item, index) => {
+            const songItem = item.type === "song" ? (item as IScheduleSong) : null;
+            const textItem = item as IScheduleText;
+            const songLink = getSongLink(item);
+            const hasChords = songItem?.blocks?.some(block => block.chords && block.chords.length > 0);
+
+            return (
+              <Card key={`schedule-item-${index}`} variant={item.type === "comment" ? "secondary" : "default"}>
+                <CardHeader>
+                  <CardHeaderText>
+                    <CardTitle>{item.title || t("view.untitled")}</CardTitle>
+                    {songItem && !!songItem.artist && (
+                      <CardDescription>{songItem.artist}</CardDescription>
+                    )}
+                    {item.type === "text" && !!textItem.subtitle && (
+                      <CardDescription>{textItem.subtitle}</CardDescription>
+                    )}
+                  </CardHeaderText>
+                  <CardHeaderActions>
+                    {songItem && (
+                      <Badge className="me-3 p-1 my-auto" variant={hasChords ? "color-4" : "outline"} title={hasChords ? t("view.chords.available") : t("view.chords.notAvailable")}>
+                        <MusicalNoteIcon className="size-2" />
+                      </Badge>
+                    )}
+                    {songLink && (
+                      <Button type="button" size="sm" title={t("actions.view")} asChild>
+                        <Link to={songLink}>
+                          <EyeIcon className="size-3" />
+                        </Link>
+                      </Button>
+                    )}
+                  </CardHeaderActions>
+                </CardHeader>
+              </Card>
+            );
+          })}
+        </div>
+
+        {isLoggedIn && (
+          <div className="flex flex-row align-start space-x-2 mt-4">
+            <Button className="flex-0" type="button" variant="secondary" asChild>
+              <Link to="/app/schedules">{t("button.back")}</Link>
+            </Button>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/app/src/routes/app/songs/view.tsx
+++ b/app/src/routes/app/songs/view.tsx
@@ -52,6 +52,8 @@ export function ViewSong() {
     }
   }
 
+  const hasChords = data.blocks?.some(block => block.chords && block.chords.length > 0);
+
   const copyShareableUrlToClipboard = async () => {
     const currentUrl = new URL(window.location.href);
     const shareUrl = `${currentUrl.protocol}//${currentUrl.host}/shared/view/${data.id}/${data.secret ?? ''}`
@@ -118,7 +120,7 @@ export function ViewSong() {
       <div className="p-2 sm:p-8">
         <h1 className="text-3xl mb-2">{data.title}</h1>
         <h2 className="text-lg mb-2 opacity-50">{data.artist}</h2>
-        <Toggle variant="outline" pressed={viewMode == 'chords'} onPressedChange={changeViewMode} className="mb-3">{t('input.viewChords')}</Toggle>
+        {hasChords && <Toggle variant="outline" pressed={viewMode == 'chords'} onPressedChange={changeViewMode} className="mb-3">{t('input.viewChords')}</Toggle>}
         <div className={cn(
           'max-w-lg space-y-3',
           viewMode === 'chords' && 'font-source-code-pro'

--- a/app/src/routes/router.tsx
+++ b/app/src/routes/router.tsx
@@ -55,6 +55,7 @@ import { loader as allSessionsLoader } from "./app/sessions/all.loader";
 
 import { Schedules as SchedulesIndex } from "./app/schedules/index";
 import { EditSchedule } from "./app/schedules/edit";
+import { ViewSchedule } from "./app/schedules/view";
 import { loader as singleScheduleLoader } from "./app/schedules/single.loader";
 import { loader as allSchedulesLoader } from "./app/schedules/all.loader";
 
@@ -117,6 +118,7 @@ export function AppRouter() {
           <Route path="schedules">
             <Route index={true} element={<SchedulesIndex />} loader={() => allSchedulesLoader({ schedulesService: services.schedulesService })} />
             <Route path="add" element={<EditSchedule edit={false} />} />
+            <Route path=":id/view" element={<ViewSchedule />} loader={(loader: LoaderFunctionArgs) => singleScheduleLoader({ params: loader.params, schedulesService: services.schedulesService })} />
             <Route path=":id/edit" element={<EditSchedule />} loader={(loader: LoaderFunctionArgs) => singleScheduleLoader({ params: loader.params, schedulesService: services.schedulesService })} />
           </Route>
         </Route>
@@ -136,6 +138,10 @@ export function AppRouter() {
           <Route path="view/:id">
             <Route index={true} element={<ViewSong />} loader={(loader: LoaderFunctionArgs) => singleSongLoader({ params: loader.params, songsService: services.songsService })} />
             <Route path=":secret" element={<ViewSong />} loader={(loader: LoaderFunctionArgs) => singleSongLoader({ params: loader.params, songsService: services.songsService, secret: loader.params.secret })} />
+          </Route>
+          <Route path="schedules/:id/">
+            <Route index={true} element={<ViewSchedule />} loader={(loader: LoaderFunctionArgs) => singleScheduleLoader({ params: loader.params, schedulesService: services.schedulesService })} />
+            <Route path=":secret" element={<ViewSchedule />} loader={(loader: LoaderFunctionArgs) => singleScheduleLoader({ params: loader.params, schedulesService: services.schedulesService, secret: loader.params.secret })} />
           </Route>
         </Route>
         <Route path="/shared" element={<ControllerSharedLayout />} errorElement={<ErrorLayout />}>

--- a/app/src/services/schedules.service.ts
+++ b/app/src/services/schedules.service.ts
@@ -14,10 +14,13 @@ export class SchedulesService extends ApiService {
     });
   }
 
-  public async getById(scheduleId: number): Promise<ISchedule | null> {
+  public async getById(scheduleId: number, secret?: string): Promise<ISchedule | null> {
+    const hasSecret = secret && secret.length > 0;
+    const secretParam = hasSecret ? `?secret=${secret}` : '';
+
     return await this.getOrFetch({
-      queryKey: ['schedules', 'id', scheduleId],
-      queryFn: async () => await this.getRequest(`/schedules/${scheduleId}`) as ISchedule,
+      queryKey: ['schedules', 'id', scheduleId, hasSecret ? secret : null],
+      queryFn: async () => await this.getRequest(`/schedules/${scheduleId}${secretParam}`) as ISchedule,
     });
   }
 

--- a/app/src/services/schedules.service.ts
+++ b/app/src/services/schedules.service.ts
@@ -14,14 +14,24 @@ export class SchedulesService extends ApiService {
     });
   }
 
-  public async getById(scheduleId: number, secret?: string): Promise<ISchedule | null> {
+  public async getById(scheduleId: number, secret?: string, force = false): Promise<ISchedule | null> {
     const hasSecret = secret && secret.length > 0;
     const secretParam = hasSecret ? `?secret=${secret}` : '';
+    const queryKey = ['schedules', 'id', scheduleId, hasSecret ? secret : null];
+
+    if (force) {
+      this.queryClient.removeQueries({ queryKey });
+    }
 
     return await this.getOrFetch({
-      queryKey: ['schedules', 'id', scheduleId, hasSecret ? secret : null],
+      queryKey,
       queryFn: async () => await this.getRequest(`/schedules/${scheduleId}${secretParam}`) as ISchedule,
     });
+  }
+
+  /** Fetches a schedule from the API, bypassing and then updating the cache. */
+  public async fetchById(scheduleId: number, secret?: string): Promise<ISchedule | null> {
+    return this.getById(scheduleId, secret, true);
   }
 
   public async add(value: Partial<ISchedule>): Promise<ISchedule | null> {

--- a/app/src/types/schedule-item.interface.ts
+++ b/app/src/types/schedule-item.interface.ts
@@ -11,5 +11,5 @@ export interface IScheduleItem {
 }
 
 export interface ISortableScheduleItem extends IScheduleItem {
-  uniqueId: number;
+  uniqueId: string;
 }

--- a/app/src/types/song.interface.ts
+++ b/app/src/types/song.interface.ts
@@ -7,6 +7,7 @@ export interface ISong {
   language?: SupportedLanguage;
   title: string
   artist?: string
+  updatedAt?: string
   blocks?: ISongPart[]
   references?: ISongReference[]
   secret?: string


### PR DESCRIPTION
Feature:
- Add API route to get schedule based on code
- Add routes to visualize schedule (both private and public)
- Added button to share public page for schedule
- Return updatedAt from songs
- Store previously selected Preview theme and ratio
- Added animation when item is added or updated in the schedule

Bugfix:
- Only show "View Chords" button in song visualization if song has chords