### PR TITLE
[Feature]: Add rehearse mode to schedules

### DIFF
--- a/app/locales/en/schedules.json
+++ b/app/locales/en/schedules.json
@@ -11,7 +11,8 @@
     "share": "Share",
     "edit": "Edit schedule",
     "delete": "Delete schedule",
-    "addItem": "Add item"
+    "addItem": "Add item",
+    "rehearsal": "Rehearse"
   },
   "button": {
     "add": "Add",
@@ -77,5 +78,13 @@
       "addToSchedule": "Add to schedule",
       "removeFromSchedule": "Remove from schedule"
     }
+  },
+  "rehearsal": {
+    "title": "Rehearse",
+    "selectSong": "Select a song",
+    "previous": "Previous song",
+    "next": "Next song",
+    "noSongs": "No songs in this schedule",
+    "print": "Print current song"
   }
 }

--- a/app/locales/en/songs.json
+++ b/app/locales/en/songs.json
@@ -125,5 +125,9 @@
   },
   "print": {
     "sequence": "Sequence"
+  },
+  "references": {
+    "play": "Play",
+    "stopPlaying": "Stop playing"
   }
 }

--- a/app/locales/pt/schedules.json
+++ b/app/locales/pt/schedules.json
@@ -11,7 +11,8 @@
     "share": "Compartilhar",
     "edit": "Editar programação",
     "delete": "Remover programação",
-    "addItem": "Adicionar item"
+    "addItem": "Adicionar item",
+    "rehearsal": "Ensaiar"
   },
   "button": {
     "add": "Adicionar",
@@ -77,5 +78,13 @@
       "addToSchedule": "Adicionar à programação",
       "removeFromSchedule": "Remover da pragramação"
     }
+  },
+  "rehearsal": {
+    "title": "Ensaiar",
+    "selectSong": "Selecione uma música",
+    "previous": "Música anterior",
+    "next": "Próxima música",
+    "noSongs": "Nenhuma música nesta programação",
+    "print": "Imprimir música atual"
   }
 }

--- a/app/locales/pt/songs.json
+++ b/app/locales/pt/songs.json
@@ -125,5 +125,9 @@
   },
   "print": {
     "sequence": "Sequência"
+  },
+  "references": {
+    "play": "Reproduzir",
+    "stopPlaying": "Parar"
   }
 }

--- a/app/src/components/app/schedules/rehearsal-nav.tsx
+++ b/app/src/components/app/schedules/rehearsal-nav.tsx
@@ -1,0 +1,80 @@
+import { Button } from "@/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { IScheduleItem, IScheduleSong } from "@/types";
+import ChevronLeftIcon from "@heroicons/react/24/solid/ChevronLeftIcon";
+import ChevronRightIcon from "@heroicons/react/24/solid/ChevronRightIcon";
+import { useTranslation } from "react-i18next";
+
+interface RehearsalNavProps {
+  items: IScheduleItem[];
+  currentIndex: number;
+  onSelect: (index: number) => void;
+  onPrevious: () => void;
+  onNext: () => void;
+  hasPrevious: boolean;
+  hasNext: boolean;
+}
+
+export function RehearsalNav({
+  items,
+  currentIndex,
+  onSelect,
+  onPrevious,
+  onNext,
+  hasPrevious,
+  hasNext,
+}: RehearsalNavProps) {
+  const { t } = useTranslation("schedules");
+
+  return (
+    <div className="flex items-center gap-x-2 px-2 sm:px-8 py-3 max-w-3xl">
+      <Button
+        type="button"
+        variant="outline"
+        size="icon"
+        onClick={onPrevious}
+        disabled={!hasPrevious}
+        title={t('rehearsal.previous')}
+      >
+        <ChevronLeftIcon className="size-4" />
+      </Button>
+      <Select
+        value={String(currentIndex)}
+        onValueChange={(value) => onSelect(Number(value))}
+      >
+        <SelectTrigger className="flex-1">
+          <SelectValue placeholder={t('rehearsal.selectSong')} />
+        </SelectTrigger>
+        <SelectContent>
+          {items.map((item, index) => {
+            const isSong = item.type === 'song';
+            const songItem = isSong ? (item as IScheduleSong) : null;
+            const label = isSong
+              ? `${index + 1}. ${item.title}${songItem?.artist ? ` - ${songItem.artist}` : ''}`
+              : `${index + 1}. ${item.title || t('view.untitled')}`;
+
+            return (
+              <SelectItem
+                key={`nav-item-${index}`}
+                value={String(index)}
+                disabled={!isSong}
+              >
+                {label}
+              </SelectItem>
+            );
+          })}
+        </SelectContent>
+      </Select>
+      <Button
+        type="button"
+        variant="outline"
+        size="icon"
+        onClick={onNext}
+        disabled={!hasNext}
+        title={t('rehearsal.next')}
+      >
+        <ChevronRightIcon className="size-4" />
+      </Button>
+    </div>
+  );
+}

--- a/app/src/components/app/songs/edit-form.tsx
+++ b/app/src/components/app/songs/edit-form.tsx
@@ -16,7 +16,7 @@ import ChevronDownIcon from "@heroicons/react/24/solid/ChevronDownIcon";
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
 import CheckIcon from "@heroicons/react/24/solid/CheckIcon";
 import { TFunction } from "i18next";
-import { EditSongParts, SongEditMode } from "@/components/app/songs/edit-parts";
+import { EditSongParts } from "@/components/app/songs/edit-parts";
 import { SongSchema } from "@/types/schemas/song.schema";
 import { z } from "zod";
 import { Toggle } from "@/components/ui/toggle";
@@ -25,6 +25,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { capitalizeText } from "@/lib/songs";
+import { useSongViewConfig } from "@/hooks/useSongViewConfig";
 
 function LanguageAndIcon({ t, language }: { t: TFunction, language: ILanguage["value"] }) {
   const lang = supportedLanguagesMap.find((lang) => lang.value === language);
@@ -39,9 +40,11 @@ function LanguageAndIcon({ t, language }: { t: TFunction, language: ILanguage["v
   );
 }
 
+type SongViewMode = 'lyrics' | 'chords';
+
 type EditSongFormProps = {
   edit?: boolean
-  defaultEditMode?: SongEditMode
+  defaultEditMode?: SongViewMode
   formValues?: z.infer<typeof SongSchema>
   additionalSubmitButtons?: ReactNode
 }
@@ -49,7 +52,7 @@ type EditSongFormProps = {
 export const EditSongForm = forwardRef((
   {
     edit = true,
-    defaultEditMode = 'lyrics',
+    defaultEditMode,
     formValues,
     additionalSubmitButtons = null,
   }: EditSongFormProps,
@@ -73,14 +76,13 @@ export const EditSongForm = forwardRef((
     defaultValues: formValues,
   });
 
-  const [editMode, setEditMode] = useState<SongEditMode>(defaultEditMode);
-  const changeEditMode = () => {
-    if (editMode === 'lyrics') {
-      setEditMode('chords');
-    } else {
-      setEditMode('lyrics');
+  const { viewMode: editMode, setViewMode, toggleViewMode: changeEditMode } = useSongViewConfig();
+
+  useEffect(() => {
+    if (defaultEditMode) {
+      setViewMode(defaultEditMode);
     }
-  }
+  }, []);
 
   const onSubmit = async (values: z.infer<typeof SongSchema>) => {
     if (hasUppercaseWarning && !ignoreWarning) return;

--- a/app/src/components/app/songs/reference-player.tsx
+++ b/app/src/components/app/songs/reference-player.tsx
@@ -1,0 +1,189 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { ISongReference } from "@/types";
+import { SpotifyCode } from "@/components/app/songs/spotify-code";
+import { getSpotifyTrackId, getYouTubeVideoId, getReferenceType } from "@/lib/songs";
+import ArrowTopRightOnSquareIcon from "@heroicons/react/24/solid/ArrowTopRightOnSquareIcon";
+import PlayIcon from "@heroicons/react/24/solid/PlayIcon";
+import StopIcon from "@heroicons/react/24/solid/StopIcon";
+import { useTranslation } from "react-i18next";
+
+// Spotify iFrame API types
+interface SpotifyIFrameAPI {
+  createController(
+    element: HTMLElement,
+    options: { uri: string; width?: string | number; height?: string | number },
+    callback: (controller: SpotifyEmbedController) => void,
+  ): void;
+}
+
+interface SpotifyEmbedController {
+  play(): void;
+  pause(): void;
+  resume(): void;
+  togglePlay(): void;
+  destroy(): void;
+  addListener(event: string, callback: (e?: unknown) => void): void;
+}
+
+declare global {
+  interface Window {
+    onSpotifyIframeApiReady?: (api: SpotifyIFrameAPI) => void;
+    SpotifyIframeApi?: SpotifyIFrameAPI;
+  }
+}
+
+/**
+ * Loads the Spotify iFrame API script and resolves with the API object.
+ * Subsequent calls return the same promise (singleton).
+ */
+let spotifyApiPromise: Promise<SpotifyIFrameAPI> | null = null;
+
+function loadSpotifyIFrameApi(): Promise<SpotifyIFrameAPI> {
+  if (spotifyApiPromise) return spotifyApiPromise;
+
+  spotifyApiPromise = new Promise<SpotifyIFrameAPI>((resolve) => {
+    // If the API is already loaded (e.g. from a previous mount)
+    if (window.SpotifyIframeApi) {
+      resolve(window.SpotifyIframeApi);
+      return;
+    }
+
+    // The API calls this global function when ready
+    window.onSpotifyIframeApiReady = (api) => {
+      window.SpotifyIframeApi = api;
+      resolve(api);
+    };
+
+    const script = document.createElement("script");
+    script.src = "https://open.spotify.com/embed/iframe-api/v1";
+    script.async = true;
+    document.head.appendChild(script);
+  });
+
+  return spotifyApiPromise;
+}
+
+function SpotifyEmbed({ trackId }: { trackId: string }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const controllerRef = useRef<SpotifyEmbedController | null>(null);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    let destroyed = false;
+
+    loadSpotifyIFrameApi().then((api) => {
+      if (destroyed || !containerRef.current) return;
+
+      api.createController(
+        containerRef.current,
+        {
+          uri: `spotify:track:${trackId}`,
+          width: "100%",
+          height: 80,
+        },
+        (controller) => {
+          if (destroyed) {
+            controller.destroy();
+            return;
+          }
+          controllerRef.current = controller;
+          controller.addListener("ready", () => {
+            if (!destroyed) {
+              controller.play();
+            }
+          });
+        },
+      );
+    });
+
+    return () => {
+      destroyed = true;
+      if (controllerRef.current) {
+        controllerRef.current.destroy();
+        controllerRef.current = null;
+      }
+    };
+  }, [trackId]);
+
+  return <div ref={containerRef} className="rounded-lg overflow-hidden" />;
+}
+
+function YouTubeEmbed({ videoId }: { videoId: string }) {
+  return (
+    <iframe
+      src={`https://www.youtube.com/embed/${videoId}?autoplay=1`}
+      width="100%"
+      height={200}
+      frameBorder="0"
+      allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+      loading="lazy"
+      className="rounded-lg"
+    />
+  );
+}
+
+interface ReferencePlayerProps {
+  references: ISongReference[];
+}
+
+export function ReferencePlayer({ references }: ReferencePlayerProps) {
+  const { t } = useTranslation("songs");
+  const [activePlayerUrl, setActivePlayerUrl] = useState<string | null>(null);
+
+  const togglePlayer = useCallback((url: string) => {
+    setActivePlayerUrl(prev => prev === url ? null : url);
+  }, []);
+
+  const activeReferenceType = activePlayerUrl ? getReferenceType(activePlayerUrl) : null;
+  const activeSpotifyTrackId = activePlayerUrl ? getSpotifyTrackId(activePlayerUrl) : null;
+  const activeYouTubeVideoId = activePlayerUrl ? getYouTubeVideoId(activePlayerUrl) : null;
+
+  return (
+    <div className="max-w-lg space-y-2 mt-3">
+      <h3 className="font-medium text-sm">{t('input.references')}</h3>
+      {references.map((reference, ix) => {
+        const refType = getReferenceType(reference.url);
+        const isPlayable = refType !== 'other';
+        const isActive = activePlayerUrl === reference.url;
+
+        return (
+          <div className="flex items-center gap-x-2" key={`references-${ix}`}>
+            <Button variant="secondary" size="icon" type="button" onClick={() => window.open(reference.url, '_blank')}>
+              <ArrowTopRightOnSquareIcon className="size-4" />
+            </Button>
+            {isPlayable && (
+              <Button
+                variant={isActive ? "default" : "secondary"}
+                size="icon"
+                type="button"
+                title={isActive ? t('references.stopPlaying') : t('references.play')}
+                onClick={() => togglePlayer(reference.url)}
+              >
+                {isActive ? <StopIcon className="size-4" /> : <PlayIcon className="size-4" />}
+              </Button>
+            )}
+            <div className="flex-1 text-sm text-muted-foreground truncate">
+              {reference.name || reference.url}
+            </div>
+            {reference.url.includes('spotify.com') && (
+              <SpotifyCode songUrl={reference.url} imgWidth={320} className="max-w-28" colorScheme="theme" />
+            )}
+          </div>
+        );
+      })}
+      {activeReferenceType === 'spotify' && activeSpotifyTrackId && (
+        <div className="mt-3">
+          <SpotifyEmbed key={activeSpotifyTrackId} trackId={activeSpotifyTrackId} />
+        </div>
+      )}
+      {activeReferenceType === 'youtube' && activeYouTubeVideoId && (
+        <div className="mt-3 rounded-lg overflow-hidden">
+          <YouTubeEmbed key={activeYouTubeVideoId} videoId={activeYouTubeVideoId} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/src/components/app/songs/song-viewer.tsx
+++ b/app/src/components/app/songs/song-viewer.tsx
@@ -1,0 +1,54 @@
+import { ReactNode } from "react";
+import { ISong } from "@/types";
+import { Toggle } from "@/components/ui/toggle";
+import { alternateLyricsAndChords } from "@/lib/songs";
+import { cn } from "@/lib/utils";
+import { ReferencePlayer } from "@/components/app/songs/reference-player";
+import { useTranslation } from "react-i18next";
+import { useSongViewConfig } from "@/hooks/useSongViewConfig";
+
+interface SongViewerProps {
+  song: ISong;
+  showReferences?: boolean;
+  children?: ReactNode;
+}
+
+export function SongViewer({ song, showReferences = true, children }: SongViewerProps) {
+  const { t } = useTranslation("songs");
+
+  const { viewMode, toggleViewMode } = useSongViewConfig();
+
+  const hasChords = song.blocks?.some(block => block.chords && block.chords.length > 0);
+
+  return (
+    <div className="p-2 sm:p-8 max-w-3xl">
+      <h1 className="text-3xl mb-2">{song.title}</h1>
+      <h2 className="text-lg mb-2 opacity-50">{song.artist}</h2>
+      {children}
+      {showReferences && song.references && song.references.length > 0 && (
+        <ReferencePlayer references={song.references} />
+      )}
+      {hasChords && (
+        <Toggle variant="outline" pressed={viewMode === 'chords'} onPressedChange={toggleViewMode} className="mb-3 mt-3">
+          {t('input.viewChords')}
+        </Toggle>
+      )}
+      <div className={cn(
+        'max-w-lg space-y-3',
+        viewMode === 'chords' && 'font-source-code-pro'
+      )}>
+        {song.blocks?.map((block, ix) => (
+          <div key={`block-${ix}`} className="border-s-1 ps-[.75em] py-[.2em] min-h-[.75em] whitespace-pre">
+            {alternateLyricsAndChords(
+              block.text,
+              viewMode === 'chords' ? block.chords : undefined,
+              {
+                chordsClassName: 'font-bold',
+              }
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/src/hooks/useSongViewConfig.tsx
+++ b/app/src/hooks/useSongViewConfig.tsx
@@ -1,0 +1,32 @@
+import { create } from 'zustand'
+import { createJSONStorage, persist } from 'zustand/middleware'
+
+type SongViewMode = 'lyrics' | 'chords';
+
+interface SongViewConfigState {
+  viewMode: SongViewMode
+  setViewMode: (mode: SongViewMode) => void
+  toggleViewMode: () => void
+}
+
+export const useSongViewConfig = create<SongViewConfigState>()(
+  persist(
+    (set, get) => ({
+      viewMode: 'lyrics',
+      setViewMode: (mode: SongViewMode) => {
+        return set({ viewMode: mode });
+      },
+      toggleViewMode: () => {
+        const current = get().viewMode;
+        return set({ viewMode: current === 'lyrics' ? 'chords' : 'lyrics' });
+      },
+    }),
+    {
+      name: "songViewConfig",
+      partialize: (state: SongViewConfigState) => ({
+        viewMode: state.viewMode,
+      }),
+      storage: createJSONStorage(() => localStorage),
+    }
+  )
+);

--- a/app/src/lib/songs.tsx
+++ b/app/src/lib/songs.tsx
@@ -102,3 +102,42 @@ export const capitalizeText = (text: string) => {
 
   return text;
 }
+
+export type ReferenceType = 'spotify' | 'youtube' | 'other';
+
+export function getSpotifyTrackId(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    if (!parsed.hostname.includes('spotify.com')) return null;
+    const match = parsed.pathname.match(/\/track\/([a-zA-Z0-9]+)/);
+    return match ? match[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+export function getYouTubeVideoId(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    const hostname = parsed.hostname.replace('www.', '');
+
+    if (hostname === 'youtube.com' || hostname === 'music.youtube.com') {
+      return parsed.searchParams.get('v');
+    }
+
+    if (hostname === 'youtu.be') {
+      const id = parsed.pathname.slice(1);
+      return id.length > 0 ? id : null;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function getReferenceType(url: string): ReferenceType {
+  if (getSpotifyTrackId(url)) return 'spotify';
+  if (getYouTubeVideoId(url)) return 'youtube';
+  return 'other';
+}

--- a/app/src/routes/app/schedules/rehearsal.tsx
+++ b/app/src/routes/app/schedules/rehearsal.tsx
@@ -1,0 +1,184 @@
+import { useCallback, useMemo, useState } from "react";
+import { ISchedule, IScheduleSong } from "@/types";
+import { Button } from "@/components/ui/button";
+import { Link, useLoaderData, useParams } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { useAuth } from "@/hooks/useAuth";
+import ShareIcon from "@heroicons/react/24/solid/ShareIcon";
+import EyeIcon from "@heroicons/react/24/solid/EyeIcon";
+import PencilIcon from "@heroicons/react/24/solid/PencilIcon";
+import PrinterIcon from "@heroicons/react/24/solid/PrinterIcon";
+import { RehearsalNav } from "@/components/app/schedules/rehearsal-nav";
+import { SongViewer } from "@/components/app/songs/song-viewer";
+import { toast } from "sonner";
+
+export function RehearsalSchedule() {
+  const { t } = useTranslation("schedules");
+  const { isLoggedIn } = useAuth();
+  const params = useParams();
+  const data = useLoaderData() as ISchedule | null;
+
+  if (!data) {
+    throw new Error("Can't find schedule");
+  }
+
+  const songIndices = useMemo(() => {
+    return data.items
+      .map((item, index) => ({ item, index }))
+      .filter(({ item }) => item.type === 'song')
+      .map(({ index }) => index);
+  }, [data.items]);
+
+  const [currentIndex, setCurrentIndex] = useState<number>(() => {
+    return songIndices.length > 0 ? songIndices[0] : -1;
+  });
+
+  const currentSongPosition = songIndices.indexOf(currentIndex);
+  const hasPrevious = currentSongPosition > 0;
+  const hasNext = currentSongPosition < songIndices.length - 1;
+
+  const goToPrevious = useCallback(() => {
+    if (hasPrevious) {
+      setCurrentIndex(songIndices[currentSongPosition - 1]);
+    }
+  }, [hasPrevious, songIndices, currentSongPosition]);
+
+  const goToNext = useCallback(() => {
+    if (hasNext) {
+      setCurrentIndex(songIndices[currentSongPosition + 1]);
+    }
+  }, [hasNext, songIndices, currentSongPosition]);
+
+  const handleSelect = useCallback((index: number) => {
+    setCurrentIndex(index);
+  }, []);
+
+  const currentItem = currentIndex >= 0 ? data.items[currentIndex] as IScheduleSong : null;
+
+  const isShared = !!params.secret;
+
+  const copyShareableUrlToClipboard = async () => {
+    const currentUrl = new URL(window.location.href);
+    const shareUrl = `${currentUrl.protocol}//${currentUrl.host}/shared/schedules/${data.id}/${data.secret ?? ''}/rehearsal`;
+    const clipboard = navigator.clipboard;
+    if (!!clipboard) {
+      await navigator.clipboard.writeText(shareUrl);
+      toast.success(t('message.share.title'), {
+        description: t('message.share.description'),
+      });
+    } else {
+      window.open(shareUrl, '_blank');
+    }
+  };
+
+  const getViewLink = () => {
+    if (isShared) {
+      return `/shared/schedules/${data.id}/${params.secret}`;
+    }
+    return `/app/schedules/${data.id}/view`;
+  };
+
+  const getPrintLink = () => {
+    if (!currentItem) return '#';
+    if (isShared) {
+      return `/shared/print/${currentItem.id}/${currentItem.secret ?? ''}`;
+    }
+    return `/app/songs/${currentItem.id}/print`;
+  };
+
+  if (songIndices.length === 0) {
+    return (
+      <>
+        <title>{t("rehearsal.title") + " - " + data.title + " - BluPresenter"}</title>
+        <div className="flex items-center px-2 sm:px-8 py-3 bg-slate-200 dark:bg-slate-900 gap-x-2">
+          <span className="text-sm">{data.title}</span>
+          <div className="buttons flex-1 flex justify-end gap-x-2">
+            <Button type="button" size="sm" title={t("actions.view")} asChild>
+              <Link to={getViewLink()}>
+                <EyeIcon className="size-3" />
+              </Link>
+            </Button>
+          </div>
+        </div>
+        <div className="p-2 sm:p-8">
+          <p className="text-muted-foreground">{t('rehearsal.noSongs')}</p>
+          {isLoggedIn && (
+            <div className="flex flex-row align-start space-x-2 mt-4">
+              <Button className="flex-0" type="button" variant="secondary" asChild>
+                <Link to={`/app/schedules/${data.id}/view`}>{t('button.back')}</Link>
+              </Button>
+            </div>
+          )}
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <title>{t("rehearsal.title") + " - " + data.title + " - BluPresenter"}</title>
+      <div className="flex items-center px-2 sm:px-8 py-3 bg-slate-200 dark:bg-slate-900 gap-x-2">
+        <span className="text-sm">{data.title}</span>
+        <div className="buttons flex-1 flex justify-end gap-x-2">
+          <Button type="button" size="sm" title={t("rehearsal.print")} asChild>
+            <Link to={getPrintLink()}>
+              <PrinterIcon className="size-3" />
+            </Link>
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            title={t("actions.share")}
+            onClick={copyShareableUrlToClipboard}
+          >
+            <ShareIcon className="size-3" />
+          </Button>
+          <Button type="button" size="sm" title={t("actions.view")} asChild>
+            <Link to={getViewLink()}>
+              <EyeIcon className="size-3" />
+            </Link>
+          </Button>
+          {isLoggedIn && (
+            <Button type="button" size="sm" title={t("actions.edit")} asChild>
+              <Link to={`/app/schedules/${data.id}/edit`}>
+                <PencilIcon className="size-3" />
+              </Link>
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <RehearsalNav
+        items={data.items}
+        currentIndex={currentIndex}
+        onSelect={handleSelect}
+        onPrevious={goToPrevious}
+        onNext={goToNext}
+        hasPrevious={hasPrevious}
+        hasNext={hasNext}
+      />
+
+      {currentItem && (
+        <SongViewer song={currentItem} />
+      )}
+
+      <RehearsalNav
+        items={data.items}
+        currentIndex={currentIndex}
+        onSelect={handleSelect}
+        onPrevious={goToPrevious}
+        onNext={goToNext}
+        hasPrevious={hasPrevious}
+        hasNext={hasNext}
+      />
+
+      {isLoggedIn && (
+        <div className="flex flex-row align-start space-x-2 px-2 sm:px-8 pb-8">
+          <Button className="flex-0" type="button" variant="secondary" asChild>
+            <Link to={`/app/schedules/${data.id}/view`}>{t('button.back')}</Link>
+          </Button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/src/routes/app/schedules/view.tsx
+++ b/app/src/routes/app/schedules/view.tsx
@@ -6,6 +6,7 @@ import EyeIcon from "@heroicons/react/24/solid/EyeIcon";
 import MusicalNoteIcon from "@heroicons/react/24/solid/MusicalNoteIcon";
 import PencilIcon from "@heroicons/react/24/solid/PencilIcon";
 import ShareIcon from "@heroicons/react/24/solid/ShareIcon";
+import PlayIcon from "@heroicons/react/24/solid/PlayIcon";
 import { parse, format } from "date-fns";
 import { Link, useLoaderData, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
@@ -50,6 +51,15 @@ export function ViewSchedule() {
     return songUrl;
   };
 
+  const getRehearsalLink = (): string => {
+    if (params.secret) {
+      return `/shared/schedules/${data.id}/${params.secret}/rehearsal`;
+    }
+    return `/app/schedules/${data.id}/rehearsal`;
+  };
+
+  const hasSongs = data.items?.some(item => item.type === 'song');
+
   const copyShareableUrlToClipboard = async () => {
     const currentUrl = new URL(window.location.href);
     const shareUrl = `${currentUrl.protocol}//${currentUrl.host}/shared/schedules/${data.id}/${data.secret ?? ''}`;
@@ -77,6 +87,13 @@ export function ViewSchedule() {
             onClick={copyShareableUrlToClipboard}>
             <ShareIcon className="size-3" />
           </Button>
+          {hasSongs && (
+            <Button type="button" size="sm" title={t("actions.rehearsal")} asChild>
+              <Link to={getRehearsalLink()}>
+                <PlayIcon className="size-3" />
+              </Link>
+            </Button>
+          )}
           {isLoggedIn && (
             <Button type="button" size="sm" title={t("actions.edit")} asChild>
               <Link to={`/app/schedules/${data.id}/edit`}>

--- a/app/src/routes/app/songs/view.tsx
+++ b/app/src/routes/app/songs/view.tsx
@@ -1,22 +1,16 @@
-import { useState } from "react";
 import { ISongWithRole, isRoleHigherOrEqualThan } from "@/types";
 import { Button } from "@/components/ui/button";
 import { Link, useLoaderData, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "@/hooks/useAuth";
-import { SpotifyCode } from "@/components/app/songs/spotify-code";
 import PencilIcon from "@heroicons/react/24/solid/PencilIcon";
 import PrinterIcon from "@heroicons/react/24/solid/PrinterIcon";
 import ShareIcon from "@heroicons/react/24/solid/ShareIcon";
 import { ControllerProvider } from "@/hooks/controller.provider";
 import { SongPreview } from "@/components/app/songs/song-preview";
-import { Toggle } from "@/components/ui/toggle";
-import { SongEditMode } from "@/components/app/songs/edit-parts";
 import { PreviewIcon } from "@/components/icons/preview";
-import ArrowTopRightOnSquareIcon from "@heroicons/react/24/solid/ArrowTopRightOnSquareIcon";
-import { alternateLyricsAndChords } from "@/lib/songs";
-import { cn } from "@/lib/utils";
 import { CopySongToOrganization } from "@/components/app/songs/copy-song-to-organization";
+import { SongViewer } from "@/components/app/songs/song-viewer";
 import { toast } from "sonner";
 
 export function ViewSong() {
@@ -42,17 +36,6 @@ export function ViewSong() {
   }
 
   const canEdit = isRoleHigherOrEqualThan(data.organization?.role, 'member');
-
-  const [viewMode, setViewMode] = useState<SongEditMode>('lyrics');
-  const changeViewMode = () => {
-    if (viewMode === 'lyrics') {
-      setViewMode('chords');
-    } else {
-      setViewMode('lyrics');
-    }
-  }
-
-  const hasChords = data.blocks?.some(block => block.chords && block.chords.length > 0);
 
   const copyShareableUrlToClipboard = async () => {
     const currentUrl = new URL(window.location.href);
@@ -117,44 +100,10 @@ export function ViewSong() {
           </ControllerProvider>}
         </div>
       </div>
-      <div className="p-2 sm:p-8">
-        <h1 className="text-3xl mb-2">{data.title}</h1>
-        <h2 className="text-lg mb-2 opacity-50">{data.artist}</h2>
-        {hasChords && <Toggle variant="outline" pressed={viewMode == 'chords'} onPressedChange={changeViewMode} className="mb-3">{t('input.viewChords')}</Toggle>}
-        <div className={cn(
-          'max-w-lg space-y-3',
-          viewMode === 'chords' && 'font-source-code-pro'
-        )}>
-          {data.blocks?.map((block, ix) => (
-            <div key={`block-${ix}`} className="border-s-1 ps-[.75em] py-[.2em] min-h-[.75em] whitespace-pre">
-              {alternateLyricsAndChords(
-                block.text,
-                viewMode === 'chords' ? block.chords : undefined,
-                {
-                  chordsClassName: 'font-bold',
-                }
-              )}
-            </div>
-          ))}
-        </div>
-        {data.references && data.references.length > 0 && <div className="max-w-lg space-y-2 mt-3">
-          <h3 className="font-medium text-sm">{t('input.references')}</h3>
-          {data.references?.map((reference, ix) => (
-            <div className="flex items-center gap-x-2" key={`references-${ix}`}>
-              <Button variant="secondary" size="icon" type="button" onClick={() => window.open(reference.url, '_blank')}><ArrowTopRightOnSquareIcon className="size-4" /></Button>
-              <div className="flex-1 text-sm text-muted-foreground truncate">
-                {reference.name || reference.url}
-              </div>
-              {reference.url.includes('spotify.com') && (
-                <SpotifyCode songUrl={reference.url} imgWidth={320} className="max-w-28" colorScheme="theme" />
-              )}
-            </div>
-          ))}
-        </div>}
-        {isLoggedIn && <div className="flex flex-row align-start space-x-2 mt-4">
-          <Button className="flex-0" type="button" variant="secondary" asChild><Link to={'/app/songs'}>{t('button.back')}</Link></Button>
-        </div>}
-      </div>
+      <SongViewer song={data} />
+      {isLoggedIn && <div className="flex flex-row align-start space-x-2 px-2 sm:px-8 pb-8">
+        <Button className="flex-0" type="button" variant="secondary" asChild><Link to={'/app/songs'}>{t('button.back')}</Link></Button>
+      </div>}
     </>
   );
 }

--- a/app/src/routes/router.tsx
+++ b/app/src/routes/router.tsx
@@ -56,6 +56,7 @@ import { loader as allSessionsLoader } from "./app/sessions/all.loader";
 import { Schedules as SchedulesIndex } from "./app/schedules/index";
 import { EditSchedule } from "./app/schedules/edit";
 import { ViewSchedule } from "./app/schedules/view";
+import { RehearsalSchedule } from "./app/schedules/rehearsal";
 import { loader as singleScheduleLoader } from "./app/schedules/single.loader";
 import { loader as allSchedulesLoader } from "./app/schedules/all.loader";
 
@@ -119,6 +120,7 @@ export function AppRouter() {
             <Route index={true} element={<SchedulesIndex />} loader={() => allSchedulesLoader({ schedulesService: services.schedulesService })} />
             <Route path="add" element={<EditSchedule edit={false} />} />
             <Route path=":id/view" element={<ViewSchedule />} loader={(loader: LoaderFunctionArgs) => singleScheduleLoader({ params: loader.params, schedulesService: services.schedulesService })} />
+            <Route path=":id/rehearsal" element={<RehearsalSchedule />} loader={(loader: LoaderFunctionArgs) => singleScheduleLoader({ params: loader.params, schedulesService: services.schedulesService })} />
             <Route path=":id/edit" element={<EditSchedule />} loader={(loader: LoaderFunctionArgs) => singleScheduleLoader({ params: loader.params, schedulesService: services.schedulesService })} />
           </Route>
         </Route>
@@ -142,6 +144,7 @@ export function AppRouter() {
           <Route path="schedules/:id/">
             <Route index={true} element={<ViewSchedule />} loader={(loader: LoaderFunctionArgs) => singleScheduleLoader({ params: loader.params, schedulesService: services.schedulesService })} />
             <Route path=":secret" element={<ViewSchedule />} loader={(loader: LoaderFunctionArgs) => singleScheduleLoader({ params: loader.params, schedulesService: services.schedulesService, secret: loader.params.secret })} />
+            <Route path=":secret/rehearsal" element={<RehearsalSchedule />} loader={(loader: LoaderFunctionArgs) => singleScheduleLoader({ params: loader.params, schedulesService: services.schedulesService, secret: loader.params.secret })} />
           </Route>
         </Route>
         <Route path="/shared" element={<ControllerSharedLayout />} errorElement={<ErrorLayout />}>


### PR DESCRIPTION
Features:
- Add new "Rehearse" mode to schedules which lists songs with lyrics, chords and references
- Added embed for YouTube and Spotify URLs on song references
- Save "View Chords" state across pages
