### PR TITLE
[Bugfix][Feature]: Multiple items

### DIFF
--- a/api/src/sessions/__tests__/sessions.service.spec.ts
+++ b/api/src/sessions/__tests__/sessions.service.spec.ts
@@ -1,0 +1,148 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import { UnauthorizedException } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import { SessionsServiceWithRequest } from '../sessions.service';
+import { Session } from '../../entities';
+import { UsersService } from '../../users/users.service';
+import { OrganizationsService } from '../../organizations/organizations.service';
+
+describe('SessionsServiceWithRequest', () => {
+  let service: SessionsServiceWithRequest;
+
+  const mockSession = (overrides: Partial<Session> = {}): Session =>
+    ({
+      id: 1,
+      orgId: 1,
+      name: 'Test Session',
+      ...overrides,
+    }) as Session;
+
+  const mockRequest = {
+    user: {
+      internal: { id: 42 },
+      organization: 1,
+    },
+  };
+
+  const mockSessionsRepository = {
+    find: jest.fn(),
+  };
+
+  const mockUsersService = {
+    findUserOrganizations: jest.fn(),
+  };
+
+  const mockOrganizationsService = {
+    userRole: jest.fn(),
+  };
+
+  const buildModule = async (request: any = mockRequest): Promise<TestingModule> =>
+    Test.createTestingModule({
+      providers: [
+        SessionsServiceWithRequest,
+        {
+          provide: getRepositoryToken(Session),
+          useValue: mockSessionsRepository,
+        },
+        {
+          provide: UsersService,
+          useValue: mockUsersService,
+        },
+        {
+          provide: OrganizationsService,
+          useValue: mockOrganizationsService,
+        },
+        {
+          provide: REQUEST,
+          useValue: request,
+        },
+      ],
+    }).compile();
+
+  beforeEach(async () => {
+    const module = await buildModule();
+    service = await module.resolve<SessionsServiceWithRequest>(SessionsServiceWithRequest);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('findAllForUserOrgs', () => {
+    it('should throw UnauthorizedException if user is not authenticated', async () => {
+      const moduleWithoutUser = await buildModule({ user: undefined });
+      const serviceWithoutUser = await moduleWithoutUser.resolve<SessionsServiceWithRequest>(
+        SessionsServiceWithRequest,
+      );
+
+      await expect(serviceWithoutUser.findAllForUserOrgs()).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('should include sessions for orgs where the user is owner, admin, or member', async () => {
+      mockUsersService.findUserOrganizations.mockResolvedValue([
+        { organization: { id: 1, name: 'Owned Org' }, role: 'owner' },
+        { organization: { id: 2, name: 'Admin Org' }, role: 'admin' },
+        { organization: { id: 3, name: 'Member Org' }, role: 'member' },
+      ]);
+      const sessions = [
+        mockSession({ id: 10, orgId: 1 }),
+        mockSession({ id: 11, orgId: 2 }),
+        mockSession({ id: 12, orgId: 3 }),
+      ];
+      mockSessionsRepository.find.mockResolvedValue(sessions);
+
+      const result = await service.findAllForUserOrgs();
+
+      expect(result).toEqual(sessions);
+      expect(mockUsersService.findUserOrganizations).toHaveBeenCalledWith(42);
+      expect(mockSessionsRepository.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { orgId: In([1, 2, 3]) },
+        }),
+      );
+    });
+
+    it('should exclude orgs where the user is only a guest', async () => {
+      mockUsersService.findUserOrganizations.mockResolvedValue([
+        { organization: { id: 1, name: 'Member Org' }, role: 'member' },
+        { organization: { id: 2, name: 'Guest Org' }, role: 'guest' },
+      ]);
+      mockSessionsRepository.find.mockResolvedValue([mockSession({ id: 10, orgId: 1 })]);
+
+      await service.findAllForUserOrgs();
+
+      // Only the member org id should reach the SQL query — guest org id 2 must be filtered out.
+      expect(mockSessionsRepository.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { orgId: In([1]) },
+        }),
+      );
+    });
+
+    it('should return an empty array (without querying) when the user is only a guest', async () => {
+      mockUsersService.findUserOrganizations.mockResolvedValue([
+        { organization: { id: 1, name: 'Guest Org A' }, role: 'guest' },
+        { organization: { id: 2, name: 'Guest Org B' }, role: 'guest' },
+      ]);
+
+      const result = await service.findAllForUserOrgs();
+
+      expect(result).toEqual([]);
+      // Avoid calling TypeORM with `In([])`, which would build an invalid SQL fragment.
+      expect(mockSessionsRepository.find).not.toHaveBeenCalled();
+    });
+
+    it('should return an empty array when the user belongs to no organizations', async () => {
+      mockUsersService.findUserOrganizations.mockResolvedValue([]);
+
+      const result = await service.findAllForUserOrgs();
+
+      expect(result).toEqual([]);
+      expect(mockSessionsRepository.find).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/api/src/sessions/sessions.service.ts
+++ b/api/src/sessions/sessions.service.ts
@@ -7,6 +7,7 @@ import { Request as ExpRequest } from 'express';
 import { UsersService } from 'src/users/users.service';
 import { OrganizationsService } from 'src/organizations/organizations.service';
 import { CreateSessionDto, UpdateSessionDto } from 'src/types';
+import { isRoleHigherOrEqualThan } from 'src/types/organization-role.type';
 
 
 @Injectable()
@@ -171,7 +172,16 @@ export class SessionsServiceWithRequest extends SessionsService {
 
     const user = this.request.user['internal'];
     userOrgs = await this.usersService.findUserOrganizations(user.id);
-    userOrgIds = userOrgs.map((org) => org.organization.id);
+    // Only include orgs where the user is a member or above. Guests must not see
+    // sessions in the cross-org listing — this mirrors the role checks on the
+    // per-org session endpoints (see SessionsController).
+    userOrgIds = userOrgs
+      .filter((org) => isRoleHigherOrEqualThan(org.role, 'member'))
+      .map((org) => org.organization.id);
+
+    if (userOrgIds.length === 0) {
+      return [];
+    }
 
     return await this.sessionsRepository.find({
       select: {

--- a/app/locales/en/controller.json
+++ b/app/locales/en/controller.json
@@ -8,7 +8,8 @@
   "plan": {
     "search": {
       "basic": "Basic",
-      "advanced": "Advanced"
+      "advanced": "Advanced",
+      "addedToSchedule": "\"{{title}}\" added to schedule"
     },
     "text": {
       "input": {
@@ -18,7 +19,8 @@
       "actions": {
         "add": "Add",
         "open": "Open"
-      }
+      },
+      "addedToSchedule": "\"{{title}}\" added to schedule"
     },
     "comment": {
       "input": {
@@ -26,7 +28,8 @@
       },
       "actions": {
         "add": "Add"
-      }
+      },
+      "addedToSchedule": "\"{{title}}\" added to schedule"
     },
     "configuration": {
       "autoAdvanceScheduleItem": "Advance schedule item when advancing slide at the end of a song",

--- a/app/locales/pt/controller.json
+++ b/app/locales/pt/controller.json
@@ -8,7 +8,8 @@
   "plan": {
     "search": {
       "basic": "Básico",
-      "advanced": "Avançado"
+      "advanced": "Avançado",
+      "addedToSchedule": "\"{{title}}\" adicionado à programação"
     },
     "text": {
       "input": {
@@ -18,7 +19,8 @@
       "actions": {
         "add": "Adicionar",
         "open": "Abrir"
-      }
+      },
+      "addedToSchedule": "\"{{title}}\" adicionado à programação"
     },
     "comment": {
       "input": {
@@ -26,7 +28,8 @@
       },
       "actions": {
         "add": "Adicionar"
-      }
+      },
+      "addedToSchedule": "\"{{title}}\" adicionado à programação"
     },
     "configuration": {
       "autoAdvanceScheduleItem": "Avançar programação ao avançar slide no final de uma música",

--- a/app/src/components/app/songs/song-editor.tsx
+++ b/app/src/components/app/songs/song-editor.tsx
@@ -833,11 +833,11 @@ export const SongEditor = forwardRef<SongEditorHandle, SongEditorProps>(function
               suppressContentEditableWarning
               spellCheck={false}
               className={cn(
-                "font-source-code-pro text-sm leading-6 outline-none whitespace-pre-wrap",
+                "font-source-code-pro text-sm leading-6 outline-none whitespace-pre overflow-x-auto",
                 "px-3 py-2",
                 "border border-l-0 border-input rounded-r-md shadow-xs dark:bg-input/30",
                 "focus-within:border-ring focus-within:ring-ring/50 focus-within:ring-[3px]",
-                "[&_.editor-line]:min-h-[1.5rem]",
+                "[&_.editor-line]:min-h-[1.5rem] [&_.editor-line]:whitespace-pre",
                 "[&_.editor-separator]:cursor-default",
               )}
               onInput={handleInput}

--- a/app/src/components/app/songs/song-editor.tsx
+++ b/app/src/components/app/songs/song-editor.tsx
@@ -213,117 +213,174 @@ export const SongEditor = forwardRef<SongEditorHandle, SongEditorProps>(function
 
   const handlePaste = (e: React.ClipboardEvent<HTMLDivElement>) => {
     e.preventDefault();
-    const text = e.clipboardData.getData('text/plain');
+    const editor = editorRef.current;
     const sel = window.getSelection();
-    if (!sel || sel.rangeCount === 0) return;
-    const range = sel.getRangeAt(0);
-    range.deleteContents();
+    if (!editor || !sel || sel.rangeCount === 0) return;
 
+    const text = e.clipboardData.getData('text/plain');
     const lines = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
+    const range = sel.getRangeAt(0);
 
-    if (lines.length <= 1) {
-      // Single line: insert as plain text node (original behaviour)
+    // Helpers ────────────────────────────────────────────────────
+    const findLineEl = (n: Node | null): HTMLElement | null => {
+      while (n && n !== editor) {
+        if (n instanceof HTMLElement && n.classList.contains('editor-line')) return n;
+        n = n.parentNode;
+      }
+      return null;
+    };
+    // Compute the text offset of (container, offset) within lineEl
+    const offsetInLine = (lineEl: HTMLElement, container: Node, offset: number): number => {
+      if (container === lineEl) {
+        let acc = 0;
+        for (let i = 0; i < offset && i < lineEl.childNodes.length; i++) {
+          acc += lineEl.childNodes[i].textContent?.length ?? 0;
+        }
+        return acc;
+      }
+      if (!lineEl.contains(container)) return (lineEl.textContent ?? '').length;
+      let acc = 0;
+      for (const child of Array.from(lineEl.childNodes)) {
+        if (child === container || child.contains(container)) {
+          if (container.nodeType === Node.TEXT_NODE && child === container) {
+            acc += offset;
+          } else {
+            // container is nested deeper; walk down counting text
+            const walker = document.createTreeWalker(child, NodeFilter.SHOW_TEXT);
+            let tn: Node | null;
+            while ((tn = walker.nextNode())) {
+              if (tn === container) { acc += offset; break; }
+              acc += (tn as Text).length;
+            }
+          }
+          return acc;
+        }
+        acc += child.textContent?.length ?? 0;
+      }
+      return acc;
+    };
+
+    const startLineEl = findLineEl(range.startContainer);
+    const endLineEl = findLineEl(range.endContainer);
+
+    // Fallback: structure not recognized — let the browser handle plain text.
+    if (!startLineEl || !endLineEl) {
+      range.deleteContents();
       const textNode = document.createTextNode(text);
       range.insertNode(textNode);
       range.setStartAfter(textNode);
       range.collapse(true);
       sel.removeAllRanges();
       sel.addRange(range);
-    } else {
-      // Multi-line: find the editor-line we're inside and split it, then
-      // insert one editor-line div per pasted line.
-      const editor = editorRef.current;
-      if (!editor) return;
-
-      // Locate the editor-line element that contains the cursor
-      let lineEl: HTMLElement | null = null;
-      let node: Node | null = range.startContainer;
-      while (node && node !== editor) {
-        if (node instanceof HTMLElement && node.classList.contains('editor-line')) {
-          lineEl = node;
-          break;
-        }
-        node = node.parentNode;
-      }
-
-      if (!lineEl) {
-        // Fallback: plain text insert if structure not found
-        const textNode = document.createTextNode(text);
-        range.insertNode(textNode);
-        range.setStartAfter(textNode);
-        range.collapse(true);
-        sel.removeAllRanges();
-        sel.addRange(range);
-      } else {
-        // Split the current line at the cursor offset to get before/after text
-        const fullText = lineEl.textContent ?? '';
-        // Determine cursor offset within the line's text
-        let cursorOffset = 0;
-        if (range.startContainer === lineEl) {
-          // cursor is directly on the element (e.g. before any child)
-          cursorOffset = 0;
-        } else if (range.startContainer.nodeType === Node.TEXT_NODE && lineEl.contains(range.startContainer)) {
-          // Walk text nodes up to the cursor
-          let offset = 0;
-          for (const child of Array.from(lineEl.childNodes)) {
-            if (child === range.startContainer) {
-              offset += range.startOffset;
-              break;
-            }
-            offset += child.textContent?.length ?? 0;
-          }
-          cursorOffset = offset;
-        } else {
-          cursorOffset = fullText.length;
-        }
-
-        const beforeText = fullText.slice(0, cursorOffset);
-        const afterText = fullText.slice(cursorOffset);
-
-        // Build the array of new line texts
-        const newLineTexts: string[] = [];
-        newLineTexts.push(beforeText + lines[0]);
-        for (let i = 1; i < lines.length - 1; i++) newLineTexts.push(lines[i]);
-        newLineTexts.push(lines[lines.length - 1] + afterText);
-
-        const partDiv = lineEl.parentElement;
-        if (!partDiv) return;
-
-        // Create new editor-line divs
-        const newDivs: HTMLElement[] = newLineTexts.map((lt) => {
-          const d = document.createElement('div');
-          d.className = lineEl!.className; // preserve type class for now; handleInput will re-detect
-          if (lt) d.textContent = lt;
-          else d.innerHTML = '<br>';
-          return d;
-        });
-
-        // Replace the original line element with the new ones
-        const lastDiv = newDivs[newDivs.length - 1];
-        lineEl.replaceWith(...newDivs);
-
-        // Place cursor at the end of the last inserted div
-        const newRange = document.createRange();
-        const lastText = lastDiv.firstChild;
-        if (lastText && lastText.nodeType === Node.TEXT_NODE) {
-          newRange.setStart(lastText, (lastText as Text).length - afterText.length);
-        } else {
-          newRange.setStart(lastDiv, 0);
-        }
-        newRange.collapse(true);
-        sel.removeAllRanges();
-        sel.addRange(newRange);
-      }
+      editor.dispatchEvent(new InputEvent('input', { bubbles: true }));
+      return;
     }
 
-    // Dispatch an input event so handleInput runs
-    editorRef.current?.dispatchEvent(new InputEvent('input', { bubbles: true }));
+    const startOffset = offsetInLine(startLineEl, range.startContainer, range.startOffset);
+    const endOffset = offsetInLine(endLineEl, range.endContainer, range.endOffset);
+
+    const beforeText = (startLineEl.textContent ?? '').slice(0, startOffset);
+    const afterText = (endLineEl.textContent ?? '').slice(endOffset);
+
+    const startPart = startLineEl.parentElement;
+    const endPart = endLineEl.parentElement;
+    if (!startPart || !endPart) return;
+
+    // Single-line paste with collapsed selection inside one line: keep simple
+    // text-node insert so we don't disturb existing chord/lyric formatting.
+    if (lines.length <= 1 && startLineEl === endLineEl && range.collapsed) {
+      const textNode = document.createTextNode(text);
+      range.insertNode(textNode);
+      range.setStartAfter(textNode);
+      range.collapse(true);
+      sel.removeAllRanges();
+      sel.addRange(range);
+      editor.dispatchEvent(new InputEvent('input', { bubbles: true }));
+      return;
+    }
+
+    // Build the new line texts
+    const newLineTexts: string[] = [];
+    if (lines.length === 1) {
+      newLineTexts.push(beforeText + lines[0] + afterText);
+    } else {
+      newLineTexts.push(beforeText + lines[0]);
+      for (let i = 1; i < lines.length - 1; i++) newLineTexts.push(lines[i]);
+      newLineTexts.push(lines[lines.length - 1] + afterText);
+    }
+
+    // Remove all selected lines/parts/separators between startLineEl and endLineEl.
+    // For cross-part selections we merge endPart into startPart.
+    // Note: startLineEl is removed below via replaceWith(); here we only clear
+    // the elements *between* it and endLineEl, plus endLineEl itself when distinct.
+    if (startPart === endPart) {
+      if (startLineEl !== endLineEl) {
+        let cur: Element | null = startLineEl.nextElementSibling;
+        while (cur && cur !== endLineEl) {
+          const next: Element | null = cur.nextElementSibling;
+          cur.remove();
+          cur = next;
+        }
+        endLineEl.remove();
+      }
+    } else {
+      // Remove trailing siblings of startLineEl within startPart.
+      while (startLineEl.nextElementSibling) startLineEl.nextElementSibling.remove();
+
+      // Remove any parts/separators strictly between startPart and endPart.
+      let between: Element | null = startPart.nextElementSibling;
+      while (between && between !== endPart) {
+        const next: Element | null = between.nextElementSibling;
+        between.remove();
+        between = next;
+      }
+
+      // Remove leading siblings of endLineEl within endPart, then endLineEl itself.
+      while (endLineEl.previousElementSibling) endLineEl.previousElementSibling.remove();
+      const tailLines = Array.from(endPart.querySelectorAll<HTMLElement>('.editor-line'))
+        .filter((el) => el !== endLineEl);
+      endLineEl.remove();
+
+      // Move any lines that were after endLineEl into startPart, then drop endPart and the separator.
+      for (const l of tailLines) startPart.appendChild(l);
+      const sep = startPart.nextElementSibling;
+      if (sep && sep.hasAttribute(SEP_ATTR)) sep.remove();
+      endPart.remove();
+    }
+
+    // Create new editor-line divs (preserve startLineEl class; handleInput re-detects types).
+    const newDivs: HTMLElement[] = newLineTexts.map((lt) => {
+      const d = document.createElement('div');
+      d.className = startLineEl.className;
+      if (lt) d.textContent = lt;
+      else d.innerHTML = '<br>';
+      return d;
+    });
+
+    // Replace startLineEl with the new divs.
+    const lastDiv = newDivs[newDivs.length - 1];
+    startLineEl.replaceWith(...newDivs);
+
+    // Place cursor at end of pasted content within the last new div.
+    const newRange = document.createRange();
+    const lastText = lastDiv.firstChild;
+    if (lastText && lastText.nodeType === Node.TEXT_NODE) {
+      const t = lastText as Text;
+      newRange.setStart(t, Math.max(0, t.length - afterText.length));
+    } else {
+      newRange.setStart(lastDiv, 0);
+    }
+    newRange.collapse(true);
+    sel.removeAllRanges();
+    sel.addRange(newRange);
+
+    editor.dispatchEvent(new InputEvent('input', { bubbles: true }));
   };
 
   // ─── Keydown: backspace merge at part boundary ────────────────
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (e.key !== 'Backspace' && e.key !== 'Delete') return;
+    if (e.key !== 'Backspace' && e.key !== 'Delete' && e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
     const editor = editorRef.current;
     const sel = window.getSelection();
     if (!editor || !sel || sel.rangeCount === 0) return;
@@ -339,6 +396,38 @@ export const SongEditor = forwardRef<SongEditorHandle, SongEditorProps>(function
 
     const partDiv = lineNode.closest('.editor-part');
     if (!partDiv) return;
+
+    // ArrowUp on first line: keep caret inside the editor (move to start of line).
+    if (e.key === 'ArrowUp') {
+      const allLines = editor.querySelectorAll('.editor-line');
+      if (allLines.length > 0 && allLines[0] === lineNode) {
+        e.preventDefault();
+        const newRange = document.createRange();
+        const first = lineNode.firstChild;
+        if (first && first.nodeType === Node.TEXT_NODE) newRange.setStart(first, 0);
+        else newRange.setStart(lineNode, 0);
+        newRange.collapse(true);
+        sel.removeAllRanges();
+        sel.addRange(newRange);
+      }
+      return;
+    }
+
+    // ArrowDown on last line: keep caret inside the editor (move to end of line).
+    if (e.key === 'ArrowDown') {
+      const allLines = editor.querySelectorAll('.editor-line');
+      if (allLines.length > 0 && allLines[allLines.length - 1] === lineNode) {
+        e.preventDefault();
+        const newRange = document.createRange();
+        const last = lineNode.lastChild;
+        if (last && last.nodeType === Node.TEXT_NODE) newRange.setStart(last, (last as Text).length);
+        else newRange.setStart(lineNode, lineNode.childNodes.length);
+        newRange.collapse(true);
+        sel.removeAllRanges();
+        sel.addRange(newRange);
+      }
+      return;
+    }
 
     if (e.key === 'Backspace') {
       const isAtStart = range.startOffset === 0 && (

--- a/app/src/components/app/songs/song-editor.tsx
+++ b/app/src/components/app/songs/song-editor.tsx
@@ -159,15 +159,21 @@ export const SongEditor = forwardRef<SongEditorHandle, SongEditorProps>(function
     const editor = editorRef.current;
     if (!editor) return;
 
-    // Detect double-empty-line in any part
+    // Detect double-empty-line in any part — only split when the empty pair
+    // is followed by more content. Trailing empty lines at the end of a part
+    // are allowed during editing (e.g., after pressing Enter to start typing).
     let needsSplit = false;
     for (const partDiv of Array.from(editor.querySelectorAll<HTMLElement>('.editor-part'))) {
       const kids = Array.from(partDiv.childNodes);
       for (let i = 0; i < kids.length - 1; i++) {
-        if ((kids[i].textContent ?? '').trim() === '' && (kids[i + 1]?.textContent ?? '').trim() === '') {
-          needsSplit = true;
-          break;
+        if ((kids[i].textContent ?? '').trim() !== '') continue;
+        if ((kids[i + 1]?.textContent ?? '').trim() !== '') continue;
+        // Require at least one non-empty sibling after the empty pair.
+        let hasContentAfter = false;
+        for (let j = i + 2; j < kids.length; j++) {
+          if ((kids[j].textContent ?? '').trim() !== '') { hasContentAfter = true; break; }
         }
+        if (hasContentAfter) { needsSplit = true; break; }
       }
       if (needsSplit) break;
     }
@@ -380,7 +386,7 @@ export const SongEditor = forwardRef<SongEditorHandle, SongEditorProps>(function
   // ─── Keydown: backspace merge at part boundary ────────────────
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (e.key !== 'Backspace' && e.key !== 'Delete' && e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
+    if (e.key !== 'Backspace' && e.key !== 'Delete' && e.key !== 'ArrowUp' && e.key !== 'ArrowDown' && e.key !== 'Enter') return;
     const editor = editorRef.current;
     const sel = window.getSelection();
     if (!editor || !sel || sel.rangeCount === 0) return;
@@ -426,6 +432,83 @@ export const SongEditor = forwardRef<SongEditorHandle, SongEditorProps>(function
         sel.removeAllRanges();
         sel.addRange(newRange);
       }
+      return;
+    }
+
+    // Enter on a lyrics line that has a chords line directly above:
+    // split both lines at the same column so chords stay aligned.
+    if (e.key === 'Enter' && !e.shiftKey) {
+      const prevSibling = lineNode.previousElementSibling;
+      const isLyricsLine = !lineNode.classList.contains('text-primary')
+        && !lineNode.classList.contains('italic');
+      const prevIsChords = prevSibling instanceof HTMLElement
+        && prevSibling.classList.contains('editor-line')
+        && prevSibling.classList.contains('text-primary');
+      if (!isLyricsLine || !prevIsChords) return;
+
+      // Compute caret offset within the lyric line's text.
+      const lyricText = lineNode.textContent ?? '';
+      let offset = 0;
+      if (range.startContainer === lineNode) {
+        for (let i = 0; i < range.startOffset && i < lineNode.childNodes.length; i++) {
+          offset += lineNode.childNodes[i].textContent?.length ?? 0;
+        }
+      } else if (lineNode.contains(range.startContainer)) {
+        for (const child of Array.from(lineNode.childNodes)) {
+          if (child === range.startContainer) { offset += range.startOffset; break; }
+          offset += child.textContent?.length ?? 0;
+        }
+      } else {
+        offset = lyricText.length;
+      }
+
+      const chordEl = prevSibling as HTMLElement;
+      const chordText = chordEl.textContent ?? '';
+
+      const lyricBefore = lyricText.slice(0, offset);
+      const lyricAfter = lyricText.slice(offset);
+      const chordBefore = chordText.slice(0, offset);
+      const chordAfter = chordText.slice(offset);
+
+      // Only split the chord line when there's actual content to redistribute
+      // on both sides — i.e. text after the caret in the lyric AND chords past
+      // the caret column. Otherwise fall back to default Enter behavior.
+      if (lyricAfter.trim() === '' || chordAfter.trim() === '') return;
+
+      e.preventDefault();
+
+      // Update the original chord/lyric lines in place.
+      const setLineText = (el: HTMLElement, text: string) => {
+        if (text) el.textContent = text;
+        else el.innerHTML = '<br>';
+      };
+      setLineText(chordEl, chordBefore);
+      setLineText(lineNode, lyricBefore);
+
+      // Build new chord + lyric lines and insert after the original lyric line.
+      const newChordLine = document.createElement('div');
+      newChordLine.className = chordEl.className;
+      setLineText(newChordLine, chordAfter);
+
+      const newLyricLine = document.createElement('div');
+      newLyricLine.className = lineNode.className;
+      setLineText(newLyricLine, lyricAfter);
+
+      const after = lineNode.nextSibling;
+      partDiv.insertBefore(newChordLine, after);
+      partDiv.insertBefore(newLyricLine, after);
+
+      // Place caret at the start of the new lyric line.
+      const newRange = document.createRange();
+      const first = newLyricLine.firstChild;
+      if (first && first.nodeType === Node.TEXT_NODE) newRange.setStart(first, 0);
+      else newRange.setStart(newLyricLine, 0);
+      newRange.collapse(true);
+      sel.removeAllRanges();
+      sel.addRange(newRange);
+
+      // Re-parse so state/form sync, types re-detected, and overlays refresh.
+      editor.dispatchEvent(new InputEvent('input', { bubbles: true }));
       return;
     }
 

--- a/app/src/components/controller/plan-comment.tsx
+++ b/app/src/components/controller/plan-comment.tsx
@@ -1,6 +1,7 @@
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod"
+import { toast } from "sonner";
 import { useController } from "@/hooks/useController";
 import { useTranslation } from "react-i18next";
 import { Input } from "@/components/ui/input";
@@ -40,10 +41,13 @@ export function PlanComment() {
   const add = async (values: z.infer<typeof textFormSchema>) => {
     const scheduleItem = getScheduleItem(values);
     addToSchedule(scheduleItem);
+    toast.success(t('plan.comment.addedToSchedule', { title: values.title }));
+    form.reset();
   }
 
   const handleAdd = (e?: React.BaseSyntheticEvent) => {
     e?.preventDefault();
+    e?.stopPropagation();
     form.handleSubmit(add)();
   }
 
@@ -64,7 +68,7 @@ export function PlanComment() {
           )}></FormField>
 
         <div className="flex justify-end space-x-2">
-          <Button type="button" title={t('plan.comment.actions.add')} onClick={handleAdd}>
+          <Button type="submit" title={t('plan.comment.actions.add')}>
             <PlusIcon className="size-3"></PlusIcon>
           </Button>
         </div>

--- a/app/src/components/controller/plan-search.tsx
+++ b/app/src/components/controller/plan-search.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 import { useAuth } from "@/hooks/useAuth";
 import { ISongWithRole } from "@/types";
 import { useServices } from "@/hooks/useServices";
@@ -42,7 +43,10 @@ export function PlanSearch({ showOpen = true }: PlanSearchProps) {
   const getButtonActions = (item: ISongWithRole) => {
     return (
       <>
-        <Button type="button" size="sm" title={t('schedule.items.addToSchedule')} onClick={() => addToSchedule(songsService.toScheduleSong(item))}>
+        <Button type="button" size="sm" title={t('schedule.items.addToSchedule')} onClick={() => {
+          addToSchedule(songsService.toScheduleSong(item));
+          toast.success(t('plan.search.addedToSchedule', { title: item.title }));
+        }}>
           <PlusIcon className="size-3"></PlusIcon>
         </Button>
         {showOpen && (

--- a/app/src/components/controller/plan-text.tsx
+++ b/app/src/components/controller/plan-text.tsx
@@ -1,6 +1,7 @@
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod"
+import { toast } from "sonner";
 import { useController } from "@/hooks/useController";
 import { useTranslation } from "react-i18next";
 import { Input } from "@/components/ui/input";
@@ -61,6 +62,8 @@ export function PlanText({ showOpen = true }: PlanTextProps) {
   const add = async (values: z.infer<typeof textFormSchema>) => {
     const scheduleItem = getScheduleItem(values);
     addToSchedule(scheduleItem);
+    toast.success(t('plan.text.addedToSchedule', { title: values.title }));
+    form.reset();
   }
 
   const open = async (values: z.infer<typeof textFormSchema>) => {
@@ -70,6 +73,7 @@ export function PlanText({ showOpen = true }: PlanTextProps) {
 
   const handleAdd = (e?: React.BaseSyntheticEvent) => {
     e?.preventDefault();
+    e?.stopPropagation();
     form.handleSubmit(add)();
   }
 
@@ -107,7 +111,7 @@ export function PlanText({ showOpen = true }: PlanTextProps) {
           )}></FormField>
 
         <div className="flex justify-end space-x-2">
-          <Button type="button" title={t('plan.text.actions.add')} onClick={handleAdd}>
+          <Button type="submit" title={t('plan.text.actions.add')}>
             <PlusIcon className="size-3"></PlusIcon>
           </Button>
           {showOpen && (

--- a/app/src/lib/__tests__/songs.spec.ts
+++ b/app/src/lib/__tests__/songs.spec.ts
@@ -283,6 +283,95 @@ Some lyrics here`;
     expect(result.blocks[1].lines[0].type).toBe('chords');
     expect(result.blocks[1].lines[1].type).toBe('lyrics');
   });
+
+  it('should NOT insert an empty block between parts separated by 1 empty line', () => {
+    // Use chord lines so the header detection does not consume lines as title/artist
+    const input = `C G Am F
+Verse line one
+
+G C F G
+Verse line two`;
+
+    const result = parseSongText(input);
+
+    expect(result.blocks).toHaveLength(2);
+    expect(result.blocks[0].lines).toHaveLength(2);
+    expect(result.blocks[1].lines).toHaveLength(2);
+  });
+
+  it('should NOT insert an empty block between parts separated by 2 empty lines', () => {
+    const input = `C G Am F
+Verse line one
+
+
+G C F G
+Verse line two`;
+
+    const result = parseSongText(input);
+
+    expect(result.blocks).toHaveLength(2);
+    expect(result.blocks[0].lines).toHaveLength(2);
+    expect(result.blocks[1].lines).toHaveLength(2);
+  });
+
+  it('should insert an empty block between parts separated by exactly 3 empty lines', () => {
+    const input = `C G Am F
+Verse line one
+
+
+
+G C F G
+Verse line two`;
+
+    const result = parseSongText(input);
+
+    expect(result.blocks).toHaveLength(3);
+    expect(result.blocks[0].lines).toHaveLength(2);
+    expect(result.blocks[1].lines).toHaveLength(0);
+    expect(result.blocks[2].lines).toHaveLength(2);
+  });
+
+  it('should insert an empty block between parts separated by more than 3 empty lines', () => {
+    const input = `C G Am F
+Verse line one
+
+
+
+
+G C F G
+Verse line two`;
+
+    const result = parseSongText(input);
+
+    expect(result.blocks).toHaveLength(3);
+    expect(result.blocks[0].lines).toHaveLength(2);
+    expect(result.blocks[1].lines).toHaveLength(0);
+    expect(result.blocks[2].lines).toHaveLength(2);
+  });
+
+  it('should insert multiple empty blocks when multiple 3+ empty line gaps exist', () => {
+    const input = `C G Am
+Part A
+
+
+
+G C F
+Part B
+
+
+
+Am F C
+Part C`;
+
+    const result = parseSongText(input);
+
+    expect(result.blocks).toHaveLength(5);
+    expect(result.blocks[0].lines).toHaveLength(2);
+    expect(result.blocks[1].lines).toHaveLength(0);
+    expect(result.blocks[2].lines).toHaveLength(2);
+    expect(result.blocks[3].lines).toHaveLength(0);
+    expect(result.blocks[4].lines).toHaveLength(2);
+  });
 });
 
 describe('transposeNote', () => {

--- a/app/src/lib/song-editor-utils.ts
+++ b/app/src/lib/song-editor-utils.ts
@@ -184,7 +184,8 @@ export function parseEditorDOM(
       }
 
       const existingLine = existing?.lines[lineIdx];
-      if (existingLine && existingLine.manuallySet && existingLine.content === content) {
+      if (existingLine && existingLine.manuallySet) {
+        // Preserve manually-set type even as the user edits the line's content.
         lines.push({ ...existingLine, content });
       } else {
         const shiftedManual = existing?.lines.find(

--- a/app/src/lib/songs.tsx
+++ b/app/src/lib/songs.tsx
@@ -578,24 +578,37 @@ export function parseSongText(fullText: string): ParsedSong {
   // Skip any remaining empty lines between header and body
   while (bodyStart < rawLines.length && rawLines[bodyStart].trim() === '') bodyStart++;
 
-  // Parse remaining lines into blocks, splitting on single empty lines
+  // Parse remaining lines into blocks, splitting on empty lines.
+  // 3 or more consecutive empty lines between parts inserts an extra empty block.
   const blocks: ISongPart[] = [];
   let currentLines: ISongPartLine[] = [];
+  let emptyLineCount = 0;
 
   for (let i = bodyStart; i < rawLines.length; i++) {
     const line = rawLines[i];
     const isEmpty = line.trim() === '';
 
     if (isEmpty) {
-      if (currentLines.length > 0) {
+      if (currentLines.length > 0 && emptyLineCount === 0) {
+        // First empty line after content — flush the current block
         blocks.push({
           id: blocks.length,
           lines: currentLines,
         });
         currentLines = [];
       }
+      emptyLineCount++;
       continue;
     }
+
+    // Non-empty line: if we had ≥3 empty lines since the last block, insert an empty block
+    if (emptyLineCount >= 3 && blocks.length > 0) {
+      blocks.push({
+        id: blocks.length,
+        lines: [],
+      });
+    }
+    emptyLineCount = 0;
 
     currentLines.push({
       type: detectLineType(line),

--- a/app/src/routes/app/organizations/index.tsx
+++ b/app/src/routes/app/organizations/index.tsx
@@ -8,7 +8,7 @@ import { useServices } from "@/hooks/useServices";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Link, NavigateFunction, useLoaderData, useNavigate, useRevalidator } from "react-router-dom";
+import { Link, useLoaderData, useNavigate, useRevalidator } from "react-router-dom";
 import ArrowPathIcon from "@heroicons/react/24/solid/ArrowPathIcon";
 import PencilIcon from "@heroicons/react/24/solid/PencilIcon";
 import TrashIcon from "@heroicons/react/24/solid/TrashIcon";
@@ -34,7 +34,7 @@ type EditOrganizationProps = {
   edit?: boolean
 }
 
-const buildColumns = (t: TFunction, userEmail: string | undefined, userRole: OrganizationRoleOptions | undefined, organizationsService: OrganizationsService, navigate: NavigateFunction) => {
+const buildColumns = (t: TFunction, userEmail: string | undefined, userRole: OrganizationRoleOptions | undefined, organizationsService: OrganizationsService, revalidate: () => void) => {
   const columns: ColumnDef<IOrganizationUser>[] = [
     {
       accessorKey: "name",
@@ -86,9 +86,15 @@ const buildColumns = (t: TFunction, userEmail: string | undefined, userRole: Org
                   size="sm"
                   variant={canDelete ? 'destructive' : 'secondary'}
                   title={t('actions.removeMember')}
-                  onClick={() => {
-                    organizationsService.removeMember(row.original.id);
-                    navigate("/app", { replace: true });
+                  onClick={async () => {
+                    try {
+                      await organizationsService.removeMember(row.original.id);
+                      revalidate();
+                    } catch (e: any) {
+                      toast.error(t('actions.removeMember'), {
+                        description: e?.message || '',
+                      });
+                    }
                   }}>
                   <TrashIcon className="size-3" />
                 </Button>
@@ -103,7 +109,7 @@ const buildColumns = (t: TFunction, userEmail: string | undefined, userRole: Org
   return columns;
 }
 
-const buildInvitationColumns = (t: TFunction, userEmail: string | undefined, userRole: OrganizationRoleOptions | undefined, organizationsService: OrganizationsService, navigate: NavigateFunction) => {
+const buildInvitationColumns = (t: TFunction, userEmail: string | undefined, userRole: OrganizationRoleOptions | undefined, organizationsService: OrganizationsService, revalidate: () => void) => {
   const copyLink = (id: number, secret: string) => {
     const link = `${window.location.origin}/signup?id=${id}&secret=${secret}`;
     navigator.clipboard.writeText(link)
@@ -179,9 +185,15 @@ const buildInvitationColumns = (t: TFunction, userEmail: string | undefined, use
                 variant="destructive"
                 title={t('actions.removeInvitation')}
                 disabled={userRole !== 'owner' && userEmail !== row.original?.inviter?.email}
-                onClick={() => {
-                  organizationsService.cancelInvitation(row.original.id);
-                  navigate("/app", { replace: true });
+                onClick={async () => {
+                  try {
+                    await organizationsService.cancelInvitation(row.original.id);
+                    revalidate();
+                  } catch (e: any) {
+                    toast.error(t('actions.removeInvitation'), {
+                      description: e?.message || '',
+                    });
+                  }
                 }}>
                 <TrashIcon className="size-3" />
               </Button>
@@ -280,8 +292,8 @@ export function EditOrganization({
     }
   }
 
-  const columns = buildColumns(t, user?.email, loadedData?.role, organizationsService, navigate);
-  const invitationColumns = buildInvitationColumns(t, user?.email, loadedData?.role, organizationsService, navigate);
+  const columns = buildColumns(t, user?.email, loadedData?.role, organizationsService, revalidate);
+  const invitationColumns = buildInvitationColumns(t, user?.email, loadedData?.role, organizationsService, revalidate);
 
   useEffect(() => {
     if (edit) {

--- a/app/src/routes/app/songs/index.tsx
+++ b/app/src/routes/app/songs/index.tsx
@@ -42,7 +42,16 @@ const buildColumns = (t: TFunction, organization: IOrganization | null, onDelete
       cell: ({ row }) => {
         return (
           <div className="flex justify-end space-x-2 -m-1">
-            {canEdit ? (
+            <Button
+              type="button"
+              size="sm"
+              title={t('actions.view')}
+              asChild>
+              <Link to={`/app/songs/${row.original.id}/view`}>
+                <EyeIcon className="size-3" />
+              </Link>
+            </Button>
+            {canEdit && (
               <Button
                 type="button"
                 size="sm"
@@ -50,16 +59,6 @@ const buildColumns = (t: TFunction, organization: IOrganization | null, onDelete
                 asChild>
                 <Link to={`/app/songs/${row.original.id}/edit`}>
                   <PencilIcon className="size-3" />
-                </Link>
-              </Button>
-            ) : (
-              <Button
-                type="button"
-                size="sm"
-                title={t('actions.view')}
-                asChild>
-                <Link to={`/app/songs/${row.original.id}/view`}>
-                  <EyeIcon className="size-3" />
                 </Link>
               </Button>
             )}


### PR DESCRIPTION
Feature:
- Ensure View button always shows on listing
- When breaking a lyrics line with chords above, auto-break chords above too
- Give visual feedback when adding an item to the schedule and clear forms

Bugfix:
- When there are 3+ empty lines between parts during import, create empty block
- Fix text replacing (paste with selected text)
- Fix "shadow top line" above first block
- Prevent long lines breaking in the editor (could lead to an impression that there are 2 lines, when there's 1)
- Fix case where line manually set to a type would auto-change
- Fix "Enter" propagation to schedule form when adding a comment in the Schedule edit page
- Don't redirect to home after excluding an organization member
- Don't show broadcast sessions for users that can't use them (guest permissions only)