### PR TITLE
feat: voice-controlled automatic slide advance

### DIFF
--- a/app/locales/en/controller.json
+++ b/app/locales/en/controller.json
@@ -94,6 +94,11 @@
     "previous": "Previous",
     "blank": "Blank",
     "logo": "Logo",
+    "voiceStart": "Start voice auto-advance",
+    "voiceStop": "Stop voice auto-advance",
+    "voiceListening": "Listening…",
+    "voiceModeNormal": "Mode: normal (advance when the slide is recognized) — click for slow",
+    "voiceModeSlow": "Mode: slow (advance only on the last word) — click for normal",
     "windows": {
       "open": "Open window",
       "closeAll": "Close all windows"

--- a/app/locales/pt/controller.json
+++ b/app/locales/pt/controller.json
@@ -94,6 +94,11 @@
     "previous": "Anterior",
     "blank": "Em branco",
     "logo": "Logo",
+    "voiceStart": "Iniciar avanço automático por voz",
+    "voiceStop": "Parar avanço automático por voz",
+    "voiceListening": "Ouvindo…",
+    "voiceModeNormal": "Modo: normal (avança ao reconhecer o slide) — clique para devagar",
+    "voiceModeSlow": "Modo: devagar (avança só na última palavra) — clique para normal",
     "windows": {
       "open": "Abrir janela",
       "closeAll": "Fechar todas janelas"

--- a/app/src/components/controller/controls.tsx
+++ b/app/src/components/controller/controls.tsx
@@ -1,21 +1,37 @@
+import { useMemo, useState } from "react";
 import { useController } from "@/hooks/useController";
 import { useTranslation } from "react-i18next";
+import { Mic, MicOff, Rabbit, Turtle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import ArrowLeftIcon from "@heroicons/react/24/outline/ArrowLeftIcon";
 import ArrowRightIcon from "@heroicons/react/24/outline/ArrowRightIcon";
 import StopSolidIcon from "@heroicons/react/24/solid/StopIcon";
 import FingerPrintSolidIcon from "@heroicons/react/24/solid/FingerPrintIcon";
 import { cn } from "@/lib/utils";
+import { useVoiceAutoAdvance, VoiceAdvanceMode } from "@/hooks/useVoiceAutoAdvance";
+import { STORAGE_KEYS } from "@/lib/storage-keys";
+import { ISlide, ISlideTextContent } from "@/types";
 
 interface ControlsProps {
   showBlank?: boolean;
   showLogo?: boolean;
+  showVoice?: boolean;
   className?: string
+}
+
+/** Extracts the plain lyrics lines from a slide for voice matching. */
+function slideToLines(slide: ISlide): string[] {
+  return (slide.content ?? [])
+    .filter((part): part is ISlideTextContent => part.type === 'lyrics')
+    .flatMap((part) => part.text.split('\n'))
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
 }
 
 export function Controls({
   showBlank = true,
   showLogo = false,
+  showVoice = false,
   className,
 }: ControlsProps) {
 
@@ -28,7 +44,38 @@ export function Controls({
     setLogo,
     overrideSlide,
     clearOverrideSlide,
+    scheduleItem,
+    selection,
+    setSelection,
   } = useController();
+
+  const slides = useMemo<string[][]>(
+    () => (scheduleItem?.slides ?? []).map(slideToLines),
+    [scheduleItem],
+  );
+  const currentIndex = selection.slide ?? 0;
+  const currentSlide = slides[currentIndex] ?? [];
+
+  const [voiceMode, setVoiceMode] = useState<VoiceAdvanceMode>(() => {
+    const saved = localStorage.getItem(STORAGE_KEYS.voiceAdvanceMode);
+    return saved === "slow" ? "slow" : "normal";
+  });
+  const toggleVoiceMode = () => {
+    setVoiceMode((prev) => {
+      const next: VoiceAdvanceMode = prev === "normal" ? "slow" : "normal";
+      localStorage.setItem(STORAGE_KEYS.voiceAdvanceMode, next);
+      return next;
+    });
+  };
+
+  const { isListening, isSupported, start, stop, lastTranscript } = useVoiceAutoAdvance({
+    currentSlide,
+    slides,
+    currentIndex,
+    mode: voiceMode,
+    onAdvance: (slideIndex) => setSelection({ slide: slideIndex, part: 0 }),
+  });
+  const voiceEnabled = showVoice && isSupported;
 
   const toggleBlank = () => {
     if (overrideSlide?.id == 'blank') {
@@ -46,25 +93,61 @@ export function Controls({
   }
 
   return (
-    <div id="controls" className={cn('p-3 flex gap-2 flex-0 justify-between items-center', className)}>
-      <Button onClick={previous} title={t('controls.previous')} className="flex-1" type="button">
-        <ArrowLeftIcon className="size-4" />
-      </Button>
-      {showBlank && (
-        <Button onClick={toggleBlank} title={t('controls.blank')} className="flex-1" type="button"
-                variant={overrideSlide?.id == 'blank' ? 'muted' : 'default'}>
-          <StopSolidIcon className="size-4" />
+    <div className="flex flex-col flex-0">
+      <div id="controls" className={cn('p-3 flex gap-2 justify-between items-center', className)}>
+        {voiceEnabled && (
+          <Button
+            onClick={isListening ? stop : start}
+            title={isListening ? t('controls.voiceStop') : t('controls.voiceStart')}
+            aria-pressed={isListening}
+            type="button"
+            size="icon"
+            variant={isListening ? 'destructive' : 'outline'}
+            className={cn('relative shrink-0', isListening && 'animate-pulse ring-2 ring-red-500 ring-offset-2')}>
+            {isListening ? <Mic className="size-4" /> : <MicOff className="size-4" />}
+          </Button>
+        )}
+        {voiceEnabled && (
+          <Button
+            onClick={toggleVoiceMode}
+            title={voiceMode === 'slow' ? t('controls.voiceModeSlow') : t('controls.voiceModeNormal')}
+            aria-label={voiceMode === 'slow' ? t('controls.voiceModeSlow') : t('controls.voiceModeNormal')}
+            type="button"
+            size="icon"
+            variant="outline"
+            className="shrink-0">
+            {voiceMode === 'slow' ? <Turtle className="size-4" /> : <Rabbit className="size-4" />}
+          </Button>
+        )}
+        <Button onClick={previous} title={t('controls.previous')} className="flex-1" type="button">
+          <ArrowLeftIcon className="size-4" />
         </Button>
-      )}
-      {showLogo && (
-        <Button onClick={toggleLogo} title={t('controls.logo')} className="flex-1" type="button"
-                variant={overrideSlide?.id == 'logo' ? 'muted' : 'default'}>
-          <FingerPrintSolidIcon className="size-4" />
+        {showBlank && (
+          <Button onClick={toggleBlank} title={t('controls.blank')} className="flex-1" type="button"
+                  variant={overrideSlide?.id == 'blank' ? 'muted' : 'default'}>
+            <StopSolidIcon className="size-4" />
+          </Button>
+        )}
+        {showLogo && (
+          <Button onClick={toggleLogo} title={t('controls.logo')} className="flex-1" type="button"
+                  variant={overrideSlide?.id == 'logo' ? 'muted' : 'default'}>
+            <FingerPrintSolidIcon className="size-4" />
+          </Button>
+        )}
+        <Button onClick={next} title={t('controls.next')} className="flex-1" type="button">
+          <ArrowRightIcon className="size-4" />
         </Button>
+      </div>
+      {voiceEnabled && isListening && (
+        <div className="px-3 pb-3 -mt-1">
+          <div className="flex items-center gap-2 rounded-md bg-muted/60 px-2 py-1 text-xs text-muted-foreground">
+            <span className="size-2 shrink-0 animate-pulse rounded-full bg-red-500" aria-hidden="true" />
+            <span className="truncate italic">
+              {lastTranscript || t('controls.voiceListening')}
+            </span>
+          </div>
+        </div>
       )}
-      <Button onClick={next} title={t('controls.next')} className="flex-1" type="button">
-        <ArrowRightIcon className="size-4" />
-      </Button>
     </div>
   );
 }

--- a/app/src/components/controller/live-panel.tsx
+++ b/app/src/components/controller/live-panel.tsx
@@ -49,7 +49,7 @@ export function LivePanel() {
         </Button>}
         {previewOpen && <PreviewWindow closeWindow={closePreview} attachControllerMode={windows.length === 0}></PreviewWindow>}
       </div>
-      <Controls></Controls>
+      <Controls showVoice></Controls>
       <div id="content" className="p-3 pt-0 flex-1 overflow-y-auto" ref={contentWrapper}>
         {scheduleItem?.slides.map((s, ix) => (
           //@ts-expect-error // TODO look into ref usage here

--- a/app/src/hooks/__tests__/useVoiceAutoAdvance.spec.tsx
+++ b/app/src/hooks/__tests__/useVoiceAutoAdvance.spec.tsx
@@ -1,0 +1,283 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useVoiceAutoAdvance } from "../useVoiceAutoAdvance";
+
+/* ------------------------------------------------------------------ */
+/* Mock the Web Speech API                                            */
+/* ------------------------------------------------------------------ */
+
+interface ResultArg {
+  transcript: string;
+  isFinal: boolean;
+}
+
+class MockSpeechRecognition {
+  lang = "";
+  continuous = false;
+  interimResults = false;
+  maxAlternatives = 1;
+  onresult: ((e: unknown) => void) | null = null;
+  onerror: ((e: unknown) => void) | null = null;
+  onend: (() => void) | null = null;
+  onstart: (() => void) | null = null;
+
+  static instances: MockSpeechRecognition[] = [];
+
+  constructor() {
+    MockSpeechRecognition.instances.push(this);
+  }
+  start() {
+    this.onstart?.();
+  }
+  stop() {
+    this.onend?.();
+  }
+  abort() {}
+
+  /** Helper: push a recognition result into the hook. */
+  emit({ transcript, isFinal }: ResultArg) {
+    this.onresult?.({
+      resultIndex: 0,
+      results: {
+        length: 1,
+        0: { length: 1, isFinal, 0: { transcript, confidence: 0.9 } },
+      },
+    });
+  }
+}
+
+function latestRecognition(): MockSpeechRecognition {
+  const list = MockSpeechRecognition.instances;
+  return list[list.length - 1];
+}
+
+describe("useVoiceAutoAdvance", () => {
+  beforeEach(() => {
+    MockSpeechRecognition.instances = [];
+    vi.useFakeTimers();
+    (window as unknown as { SpeechRecognition: unknown }).SpeechRecognition =
+      MockSpeechRecognition;
+    (window as unknown as { webkitSpeechRecognition: unknown }).webkitSpeechRecognition =
+      MockSpeechRecognition;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (window as unknown as { SpeechRecognition?: unknown }).SpeechRecognition;
+    delete (window as unknown as { webkitSpeechRecognition?: unknown })
+      .webkitSpeechRecognition;
+  });
+
+  // Two identical choruses back to back (the real "Leão de Judá" case).
+  const chorus = ["Leão de Judá", "Leão de Judá", "Leão de Judá", "Prevaleceu"];
+  const verse = ["E os povos verão e virão", "Pois a Sua justiça", "Governará"];
+  const slides = [chorus, chorus, verse];
+
+  it("reports support and exposes controls", () => {
+    const { result } = renderHook(() =>
+      useVoiceAutoAdvance({
+        currentSlide: slides[0],
+        slides,
+        currentIndex: 0,
+        onAdvance: () => {},
+      }),
+    );
+    expect(result.current.isSupported).toBe(true);
+    expect(result.current.isListening).toBe(false);
+  });
+
+  it("advances when the whole slide is covered even if the final word is misheard", () => {
+    // Real-world case: "Prevaleceu" gets recognized as "por favor". The last
+    // line never matches, but the slide as a whole does, so it must advance.
+    const onAdvance = vi.fn();
+    const { result } = renderHook(() =>
+      useVoiceAutoAdvance({
+        currentSlide: slides[0],
+        slides,
+        currentIndex: 0,
+        onAdvance,
+      }),
+    );
+    act(() => result.current.start());
+    const rec = latestRecognition();
+
+    act(() => rec.emit({ transcript: "leão de judá leão de judá leão de judá", isFinal: false }));
+    expect(onAdvance).not.toHaveBeenCalled(); // body only -> not yet
+    act(() => rec.emit({ transcript: "leão de judas leão de judá leão de judá por favor", isFinal: true }));
+
+    expect(onAdvance).toHaveBeenCalledTimes(1);
+    expect(onAdvance).toHaveBeenCalledWith(1);
+  });
+
+  it("slow mode does NOT use the whole-slide fallback (requires the last line)", () => {
+    const onAdvance = vi.fn();
+    const { result } = renderHook(() =>
+      useVoiceAutoAdvance({
+        currentSlide: slides[0],
+        slides,
+        currentIndex: 0,
+        mode: "slow",
+        onAdvance,
+      }),
+    );
+    act(() => result.current.start());
+    const rec = latestRecognition();
+
+    // Whole slide covered but final word misheard -> in slow mode this must NOT advance.
+    act(() => rec.emit({ transcript: "leão de judas leão de judá leão de judá por favor", isFinal: true }));
+    expect(onAdvance).not.toHaveBeenCalled();
+
+    // Actually hearing the last line advances.
+    act(() => rec.emit({ transcript: "leão de judá leão de judá leão de judá prevaleceu", isFinal: true }));
+    expect(onAdvance).toHaveBeenCalledTimes(1);
+    expect(onAdvance).toHaveBeenCalledWith(1);
+  });
+
+  it("slow mode does NOT auto-advance via the periodic error-correction", () => {
+    // Distinct slides so a different slide would score better and tempt the
+    // error-correction pass to jump on its own.
+    const distinct = [
+      ["Primeira parte aqui", "Termina assim"],
+      ["Segunda parte distinta", "Conclui diferente"],
+      ["Terceira e final", "Amém"],
+    ];
+    const onAdvance = vi.fn();
+    const { result } = renderHook(() =>
+      useVoiceAutoAdvance({
+        currentSlide: distinct[0],
+        slides: distinct,
+        currentIndex: 0,
+        mode: "slow",
+        onAdvance,
+      }),
+    );
+    act(() => result.current.start());
+    const rec = latestRecognition();
+
+    // Speak words that match a DIFFERENT slide (slide 1), without hitting slide 0's
+    // last line. In slow mode the periodic correction must NOT jump.
+    act(() => rec.emit({ transcript: "segunda parte distinta conclui diferente", isFinal: true }));
+    // Let several error-correction intervals (3s each) elapse.
+    act(() => vi.advanceTimersByTime(7000));
+
+    expect(onAdvance).not.toHaveBeenCalled();
+  });
+
+  it("advances exactly ONE slide when the final word is sustained across identical choruses", () => {
+    const onAdvance = vi.fn();
+    const { result } = renderHook(() =>
+      useVoiceAutoAdvance({
+        currentSlide: slides[0],
+        slides,
+        currentIndex: 0,
+        onAdvance,
+      }),
+    );
+
+    act(() => result.current.start());
+    const rec = latestRecognition();
+
+    // Sing the chorus, then hold "prevaleceu" over several interim results.
+    act(() => rec.emit({ transcript: "leão de judá leão de judá leão de judá prevaleceu", isFinal: false }));
+    act(() => rec.emit({ transcript: "leão de judá leão de judá leão de judá prevaleceu", isFinal: false }));
+    act(() => rec.emit({ transcript: "leão de judá leão de judá leão de judá prevaleceu prevaleceu", isFinal: false }));
+    act(() => rec.emit({ transcript: "prevaleceu prevaleceu prevaleceu", isFinal: false }));
+    act(() => rec.emit({ transcript: "prevaleceu prevaleceu prevaleceu prevaleceu", isFinal: true }));
+
+    // Sustained word must NOT walk through the second identical chorus.
+    expect(onAdvance).toHaveBeenCalledTimes(1);
+    expect(onAdvance).toHaveBeenCalledWith(1);
+  });
+
+  it("re-arms and advances again when the next (identical) chorus is sung from the top", () => {
+    const onAdvance = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ currentIndex }) =>
+        useVoiceAutoAdvance({
+          currentSlide: slides[currentIndex],
+          slides,
+          currentIndex,
+          onAdvance,
+        }),
+      { initialProps: { currentIndex: 0 } },
+    );
+
+    act(() => result.current.start());
+    const rec = latestRecognition();
+
+    // Advance 0 -> 1 by reaching the last line.
+    act(() => rec.emit({ transcript: "leão de judá leão de judá leão de judá prevaleceu", isFinal: true }));
+    expect(onAdvance).toHaveBeenLastCalledWith(1);
+    rerender({ currentIndex: 1 });
+
+    act(() => vi.advanceTimersByTime(1100)); // past the cooldown
+
+    // Singing the next identical chorus commits new speech after the consume
+    // point, so reaching its end advances 1 -> 2.
+    act(() => rec.emit({ transcript: "leão de judá leão de judá leão de judá prevaleceu", isFinal: true }));
+
+    expect(onAdvance).toHaveBeenCalledTimes(2);
+    expect(onAdvance).toHaveBeenLastCalledWith(2);
+  });
+
+  it("advances promptly when a verse is sung to its end (not late)", () => {
+    const verses = [
+      ["E os povos verão e virão", "A Sião aprender Sua lei", "Pois a Sua justiça", "Governará"],
+      ["Outro verso aqui", "Final"],
+    ];
+    const onAdvance = vi.fn();
+    const { result } = renderHook(() =>
+      useVoiceAutoAdvance({
+        currentSlide: verses[0],
+        slides: verses,
+        currentIndex: 0,
+        onAdvance,
+      }),
+    );
+    act(() => result.current.start());
+    const rec = latestRecognition();
+
+    act(() => rec.emit({ transcript: "e os povos verão e virão", isFinal: false }));
+    act(() => rec.emit({ transcript: "e os povos verão e virão a sião aprender sua lei", isFinal: false }));
+    act(() => rec.emit({ transcript: "e os povos verão e virão a sião aprender sua lei pois a sua justiça", isFinal: false }));
+    expect(onAdvance).not.toHaveBeenCalled(); // not on the penultimate line
+
+    // The moment the last line is sung, it advances.
+    act(() => rec.emit({ transcript: "a sião aprender sua lei pois a sua justiça governará", isFinal: true }));
+    expect(onAdvance).toHaveBeenCalledWith(1);
+  });
+
+  it("keeps advancing during run-on singing with no pause between slides", () => {
+    const verses = [
+      ["Ouve-se em todos os povos", "Que um novo Rei surgiu", "Impérios reconhecem", "Que Sua destra reinará"],
+      ["Leão de Judá", "Leão de Judá", "Leão de Judá", "Prevaleceu"],
+      ["Fim", "Amém"],
+    ];
+    const onAdvance = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ currentIndex }) =>
+        useVoiceAutoAdvance({
+          currentSlide: verses[currentIndex],
+          slides: verses,
+          currentIndex,
+          onAdvance,
+        }),
+      { initialProps: { currentIndex: 0 } },
+    );
+    act(() => result.current.start());
+    const rec = latestRecognition();
+
+    // Whole first verse arrives as one growing interim, then finalizes -> advance to 1.
+    act(() => rec.emit({ transcript: "ouve-se em todos os povos que um novo rei surgiu impérios reconhecem que sua destra reinará", isFinal: true }));
+    expect(onAdvance).toHaveBeenLastCalledWith(1);
+    rerender({ currentIndex: 1 });
+
+    act(() => vi.advanceTimersByTime(1100));
+
+    // Singing straight into the chorus (no pause) must still advance to 2,
+    // because the consumed prefix excludes the previous verse's last line.
+    act(() => rec.emit({ transcript: "leão de judá leão de judá leão de judá prevaleceu", isFinal: true }));
+    expect(onAdvance).toHaveBeenCalledTimes(2);
+    expect(onAdvance).toHaveBeenLastCalledWith(2);
+  });
+});

--- a/app/src/hooks/useVoiceAutoAdvance.ts
+++ b/app/src/hooks/useVoiceAutoAdvance.ts
@@ -89,6 +89,12 @@ const CORRECTION_INTERVAL_MS = 3000;
 const WINDOW_WORDS = 24;
 /** Minimum gap between two automatic transitions. */
 const ADVANCE_COOLDOWN_MS = 1000;
+/**
+ * Delay before relaunching recognition after it ends. A small gap (instead of
+ * restarting synchronously) prevents the busy restart loop that makes the tab
+ * flicker / the mic appear to connect and disconnect repeatedly.
+ */
+const RECOGNITION_RESTART_DELAY_MS = 300;
 
 /**
  * - `normal`: advance as soon as the slide is recognized — tolerant of the
@@ -144,6 +150,11 @@ export function useVoiceAutoAdvance({
   // without us tearing down and recreating the recognizer on every render.
   const recognitionRef = useRef<SpeechRecognitionLike | null>(null);
   const shouldListenRef = useRef(false);
+  // Guards against the "tab flickers / mic connects-disconnects" restart loop:
+  // a pending restart timer, and whether the last error was fatal (permission
+  // denied, mic busy, etc.) so we don't keep relaunching recognition.
+  const restartTimerRef = useRef<number | null>(null);
+  const recognitionActiveRef = useRef(false);
   // Recognized speech is split into a committed buffer (finalized results, which
   // only ever grow) and a replaceable interim tail (the in-progress phrase).
   const committedRef = useRef("");
@@ -285,31 +296,59 @@ export function useVoiceAutoAdvance({
     const SpeechRecognitionImpl = getSpeechRecognition();
     if (!SpeechRecognitionImpl) return;
 
+    // Never run two recognizers at once (a second one steals the mic and causes
+    // the connect/disconnect flicker). Tear down any previous instance first.
+    const previous = recognitionRef.current;
+    if (previous) {
+      previous.onresult = null;
+      previous.onerror = null;
+      previous.onend = null;
+      try {
+        previous.abort();
+      } catch {
+        // Ignore.
+      }
+    }
+
     const recognition = new SpeechRecognitionImpl();
     recognition.lang = lang;
     recognition.continuous = true;
     recognition.interimResults = true;
     recognition.maxAlternatives = 1;
 
+    recognition.onstart = () => {
+      recognitionActiveRef.current = true;
+    };
     recognition.onresult = handleResult;
     recognition.onerror = (event) => {
-      // "no-speech"/"aborted" are routine; surface anything else.
-      if (event.error !== "no-speech" && event.error !== "aborted") {
-        console.warn("[useVoiceAutoAdvance] recognition error:", event.error);
+      // Fatal errors must NOT trigger a restart, otherwise we loop forever
+      // re-requesting the mic (the tab "flickers" connecting/disconnecting).
+      const fatal =
+        event.error === "not-allowed" ||
+        event.error === "service-not-allowed" ||
+        event.error === "audio-capture";
+      if (fatal) {
+        console.warn("[useVoiceAutoAdvance] microfone indisponível:", event.error);
+        shouldListenRef.current = false;
+        setIsListening(false);
       }
     };
     recognition.onend = () => {
-      // Browsers stop recognition on silence even when `continuous`; restart it
-      // ourselves while the user still wants to listen.
-      if (shouldListenRef.current) {
-        try {
-          recognition.start();
-        } catch {
-          // start() throws if it is already starting; safe to ignore.
-        }
-      } else {
+      recognitionActiveRef.current = false;
+      // Browsers stop recognition on silence even when `continuous`. Restart it
+      // ourselves while the user still wants to listen — but on a short timer,
+      // never synchronously, so a rapid end→start cycle can't busy-loop.
+      if (!shouldListenRef.current) {
         setIsListening(false);
+        return;
       }
+      if (restartTimerRef.current !== null) return;
+      restartTimerRef.current = window.setTimeout(() => {
+        restartTimerRef.current = null;
+        if (shouldListenRef.current && !recognitionActiveRef.current) {
+          startInternal();
+        }
+      }, RECOGNITION_RESTART_DELAY_MS);
     };
 
     recognitionRef.current = recognition;
@@ -339,6 +378,10 @@ export function useVoiceAutoAdvance({
   const stop = useCallback(() => {
     shouldListenRef.current = false;
     setIsListening(false);
+    if (restartTimerRef.current !== null) {
+      window.clearTimeout(restartTimerRef.current);
+      restartTimerRef.current = null;
+    }
     const recognition = recognitionRef.current;
     if (recognition) {
       try {
@@ -402,8 +445,13 @@ export function useVoiceAutoAdvance({
   useEffect(() => {
     return () => {
       shouldListenRef.current = false;
+      if (restartTimerRef.current !== null) {
+        window.clearTimeout(restartTimerRef.current);
+        restartTimerRef.current = null;
+      }
       const recognition = recognitionRef.current;
       if (recognition) {
+        recognition.onstart = null;
         recognition.onresult = null;
         recognition.onerror = null;
         recognition.onend = null;

--- a/app/src/hooks/useVoiceAutoAdvance.ts
+++ b/app/src/hooks/useVoiceAutoAdvance.ts
@@ -1,0 +1,420 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { matchSlide, normalizeText, scoreLine } from "@/lib/fuzzy";
+
+/* -------------------------------------------------------------------------- */
+/* Minimal Web Speech API typings                                             */
+/* The standard TS DOM lib does not ship SpeechRecognition types, so we       */
+/* declare just enough of the surface we use here.                            */
+/* -------------------------------------------------------------------------- */
+
+interface SpeechRecognitionAlternativeLike {
+  transcript: string;
+  confidence: number;
+}
+
+interface SpeechRecognitionResultLike {
+  readonly length: number;
+  isFinal: boolean;
+  [index: number]: SpeechRecognitionAlternativeLike;
+}
+
+interface SpeechRecognitionResultListLike {
+  readonly length: number;
+  [index: number]: SpeechRecognitionResultLike;
+}
+
+interface SpeechRecognitionEventLike {
+  resultIndex: number;
+  results: SpeechRecognitionResultListLike;
+}
+
+interface SpeechRecognitionErrorEventLike {
+  error: string;
+}
+
+interface SpeechRecognitionLike {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  maxAlternatives: number;
+  start: () => void;
+  stop: () => void;
+  abort: () => void;
+  onresult: ((event: SpeechRecognitionEventLike) => void) | null;
+  onerror: ((event: SpeechRecognitionErrorEventLike) => void) | null;
+  onend: (() => void) | null;
+  onstart: (() => void) | null;
+}
+
+type SpeechRecognitionConstructor = new () => SpeechRecognitionLike;
+
+function getSpeechRecognition(): SpeechRecognitionConstructor | null {
+  if (typeof window === "undefined") return null;
+  const w = window as typeof window & {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  };
+  return w.SpeechRecognition ?? w.webkitSpeechRecognition ?? null;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Tunable thresholds (all scores are in the [0, 1] range)                    */
+/* -------------------------------------------------------------------------- */
+
+/** Last-line score (final result) needed to advance one slide. */
+const FINAL_ADVANCE_THRESHOLD = 0.6;
+/** Same, but stricter for interim (non-final) results. */
+const INTERIM_ADVANCE_THRESHOLD = 0.7;
+/**
+ * Fallback when the recognizer mishears the final word (e.g. "Prevaleceu" heard
+ * as "por favor"): advance if the WHOLE slide has been covered — the analyzed
+ * speech matches the entire slide text this well AND spans at least as many
+ * words as the slide. Stricter than the last-line trigger so it can't fire
+ * mid-slide.
+ */
+const WHOLE_SLIDE_FINAL_THRESHOLD = 0.7;
+/** Same, but stricter for interim (non-final) results. */
+const WHOLE_SLIDE_INTERIM_THRESHOLD = 0.8;
+/** How much better another slide must score to trigger an error-correction jump. */
+const CORRECTION_MARGIN = 0.2;
+/**
+ * Jumping *backward* is riskier (repeated choruses look alike), so it also
+ * requires a near-identical line on the target slide. Forward jumps keep the
+ * looser margin-only behavior.
+ */
+const BACKWARD_LINE_THRESHOLD = 0.9;
+/** How often the error-correction pass runs. */
+const CORRECTION_INTERVAL_MS = 3000;
+/** Only the last N recognized words are compared against the slides. */
+const WINDOW_WORDS = 24;
+/** Minimum gap between two automatic transitions. */
+const ADVANCE_COOLDOWN_MS = 1000;
+
+/**
+ * - `normal`: advance as soon as the slide is recognized — tolerant of the
+ *   recognizer mishearing the final word (whole-slide fallback enabled).
+ * - `slow`: only advance once the actual LAST line/word of the slide is heard
+ *   (no whole-slide fallback). Safer against advancing early.
+ */
+export type VoiceAdvanceMode = "normal" | "slow";
+
+export interface UseVoiceAutoAdvanceOptions {
+  /** Lines of the slide currently being shown. */
+  currentSlide: string[];
+  /** All slides (each an array of lines), used for error-correction jumps. */
+  slides: string[][];
+  /** Index of the current slide within `slides`. */
+  currentIndex: number;
+  /** Called with the slide index the presentation should jump to. */
+  onAdvance: (slideIndex: number) => void;
+  /** Detection strictness; defaults to `normal`. */
+  mode?: VoiceAdvanceMode;
+  /** Recognition language; defaults to Brazilian Portuguese. */
+  lang?: string;
+}
+
+export interface UseVoiceAutoAdvanceResult {
+  isListening: boolean;
+  isSupported: boolean;
+  start: () => void;
+  stop: () => void;
+  lastTranscript: string;
+  confidence: number;
+}
+
+/**
+ * Encapsulates browser speech recognition and the logic that auto-advances
+ * slides when the spoken words match the current (or another) slide.
+ */
+export function useVoiceAutoAdvance({
+  currentSlide,
+  slides,
+  currentIndex,
+  onAdvance,
+  mode = "normal",
+  lang = "pt-BR",
+}: UseVoiceAutoAdvanceOptions): UseVoiceAutoAdvanceResult {
+  const isSupported = useMemo(() => getSpeechRecognition() !== null, []);
+
+  const [isListening, setIsListening] = useState(false);
+  const [lastTranscript, setLastTranscript] = useState("");
+  const [confidence, setConfidence] = useState(0);
+
+  // Long-lived refs so the recognition callbacks always read fresh values
+  // without us tearing down and recreating the recognizer on every render.
+  const recognitionRef = useRef<SpeechRecognitionLike | null>(null);
+  const shouldListenRef = useRef(false);
+  // Recognized speech is split into a committed buffer (finalized results, which
+  // only ever grow) and a replaceable interim tail (the in-progress phrase).
+  const committedRef = useRef("");
+  const interimRef = useRef("");
+  // Number of words (over committed + interim) already accounted for at the last
+  // advance. Detection only analyzes words BEYOND this count, so the previous
+  // slide's line can't keep re-triggering — even across run-on singing with no
+  // pauses, and even when an interim result later finalizes (the word count is
+  // preserved when interim → committed, so the boundary stays aligned).
+  const consumedWordsRef = useRef(0);
+  const lastAdvanceRef = useRef(0);
+
+  const propsRef = useRef({ currentSlide, slides, currentIndex, onAdvance, mode });
+  useEffect(() => {
+    propsRef.current = { currentSlide, slides, currentIndex, onAdvance, mode };
+  }, [currentSlide, slides, currentIndex, onAdvance, mode]);
+
+  /** All recognized words so far (committed + in-progress interim). */
+  const allWords = useCallback((): string[] => {
+    return `${committedRef.current} ${interimRef.current}`
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean);
+  }, []);
+
+  /** Speech to analyze for the current slide: everything not yet consumed. */
+  const analysisWindow = useCallback((): string => {
+    return allWords().slice(consumedWordsRef.current).slice(-WINDOW_WORDS).join(" ");
+  }, [allWords]);
+
+  const advanceTo = useCallback((slideIndex: number) => {
+    const now = Date.now();
+    if (now - lastAdvanceRef.current < ADVANCE_COOLDOWN_MS) return;
+    lastAdvanceRef.current = now;
+    // Consume everything heard so far so the next slide starts from new speech.
+    consumedWordsRef.current = allWords().length;
+    propsRef.current.onAdvance(slideIndex);
+  }, [allWords]);
+
+  /**
+   * Score of `line` against just the trailing end of `transcript` (line length
+   * plus a couple of words of slack), so we measure whether the line is being
+   * sung *right now* rather than merely present somewhere earlier in the buffer.
+   */
+  const tailScore = useCallback((transcript: string, line: string): number => {
+    const words = transcript.split(" ").filter(Boolean);
+    if (words.length === 0) return 0;
+    const lineWords = normalizeText(line).split(" ").length;
+    const tail = words.slice(-(lineWords + 2)).join(" ");
+    return scoreLine(tail, line);
+  }, []);
+
+  const runDetection = useCallback(
+    (isFinal: boolean) => {
+      const { currentSlide, slides, currentIndex, mode } = propsRef.current;
+      if (currentSlide.length === 0 || currentIndex >= slides.length - 1) return;
+
+      // The cooldown both rate-limits transitions and absorbs a sustained final
+      // word (it keeps scoring high but can't fire again within the window).
+      if (Date.now() - lastAdvanceRef.current < ADVANCE_COOLDOWN_MS) return;
+
+      const transcript = analysisWindow();
+      if (!transcript) return;
+
+      const threshold = isFinal ? FINAL_ADVANCE_THRESHOLD : INTERIM_ADVANCE_THRESHOLD;
+      const lastLine = currentSlide[currentSlide.length - 1];
+      const lastScore = lastLine ? tailScore(transcript, lastLine) : 0;
+      const slideWordCount = normalizeText(currentSlide.join(" ")).split(" ").filter(Boolean).length;
+
+      // `slow` mode requires the actual last line to be heard AND that roughly
+      // the whole slide has been sung since we entered it. The word-count gate is
+      // what stops slides made of identical repeated lines (e.g. a 3× bridge)
+      // from advancing on the first line — there the "last line" matches
+      // immediately, so only the count tells them apart. Uses the uncapped
+      // words-since-advance (not the windowed transcript, which is capped).
+      if (mode === "slow") {
+        const wordsSinceAdvance = allWords().length - consumedWordsRef.current;
+        if (lastScore < threshold) return;
+        if (wordsSinceAdvance < slideWordCount - 1) return;
+        advanceTo(currentIndex + 1);
+        return;
+      }
+
+      // `normal` mode adds a fallback for when the recognizer mishears the final
+      // word: advance if the analyzed speech has covered the WHOLE slide (matches
+      // the full slide text and spans at least as many words as the slide).
+      // Stricter than the last-line trigger so it can't fire mid-slide.
+      const wholeText = currentSlide.join(" ");
+      const wholeWords = normalizeText(wholeText).split(" ").filter(Boolean).length;
+      const windowWords = transcript.split(" ").filter(Boolean).length;
+      const wholeScore = scoreLine(transcript, wholeText);
+      const wholeThreshold = isFinal ? WHOLE_SLIDE_FINAL_THRESHOLD : WHOLE_SLIDE_INTERIM_THRESHOLD;
+      const wholeCovered = wholeScore >= wholeThreshold && windowWords >= wholeWords;
+
+      if (lastScore < threshold && !wholeCovered) return;
+
+      advanceTo(currentIndex + 1);
+    },
+    [advanceTo, analysisWindow, tailScore, allWords],
+  );
+
+  const handleResult = useCallback(
+    (event: SpeechRecognitionEventLike) => {
+      let finalText = "";
+      let interimText = "";
+      let maxConfidence = 0;
+
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const result = event.results[i];
+        const alternative = result[0];
+        if (!alternative) continue;
+        if (result.isFinal) {
+          finalText += alternative.transcript + " ";
+          maxConfidence = Math.max(maxConfidence, alternative.confidence || 0);
+        } else {
+          interimText += alternative.transcript + " ";
+        }
+      }
+
+      if (finalText) {
+        // Finalizing interim text: same words, just promoted to committed. The
+        // total word count is preserved, so consumedWordsRef stays aligned.
+        committedRef.current = `${committedRef.current} ${finalText}`.trim();
+        interimRef.current = "";
+      } else {
+        interimRef.current = interimText.trim();
+      }
+
+      const combined = `${committedRef.current} ${interimRef.current}`.trim();
+      setLastTranscript(combined);
+      if (maxConfidence > 0) setConfidence(maxConfidence);
+
+      runDetection(finalText.length > 0);
+    },
+    [runDetection],
+  );
+
+  const startInternal = useCallback(() => {
+    const SpeechRecognitionImpl = getSpeechRecognition();
+    if (!SpeechRecognitionImpl) return;
+
+    const recognition = new SpeechRecognitionImpl();
+    recognition.lang = lang;
+    recognition.continuous = true;
+    recognition.interimResults = true;
+    recognition.maxAlternatives = 1;
+
+    recognition.onresult = handleResult;
+    recognition.onerror = (event) => {
+      // "no-speech"/"aborted" are routine; surface anything else.
+      if (event.error !== "no-speech" && event.error !== "aborted") {
+        console.warn("[useVoiceAutoAdvance] recognition error:", event.error);
+      }
+    };
+    recognition.onend = () => {
+      // Browsers stop recognition on silence even when `continuous`; restart it
+      // ourselves while the user still wants to listen.
+      if (shouldListenRef.current) {
+        try {
+          recognition.start();
+        } catch {
+          // start() throws if it is already starting; safe to ignore.
+        }
+      } else {
+        setIsListening(false);
+      }
+    };
+
+    recognitionRef.current = recognition;
+    try {
+      recognition.start();
+    } catch {
+      // Ignore InvalidStateError when start() is called too quickly.
+    }
+  }, [handleResult, lang]);
+
+  const resetBuffers = useCallback(() => {
+    committedRef.current = "";
+    interimRef.current = "";
+    consumedWordsRef.current = 0;
+  }, []);
+
+  const start = useCallback(() => {
+    if (!isSupported || shouldListenRef.current) return;
+    shouldListenRef.current = true;
+    resetBuffers();
+    setLastTranscript("");
+    setConfidence(0);
+    setIsListening(true);
+    startInternal();
+  }, [isSupported, startInternal, resetBuffers]);
+
+  const stop = useCallback(() => {
+    shouldListenRef.current = false;
+    setIsListening(false);
+    const recognition = recognitionRef.current;
+    if (recognition) {
+      try {
+        recognition.stop();
+      } catch {
+        // Ignore if it was not running.
+      }
+    }
+  }, []);
+
+  // When the slide changes by MANUAL control (clicking next/previous), consume
+  // whatever has been heard so far so the new slide matches only fresh speech.
+  // (Automatic advances already consume inside advanceTo.)
+  useEffect(() => {
+    consumedWordsRef.current = allWords().length;
+  }, [currentIndex, allWords]);
+
+  // Periodic error-correction: if some other slide matches noticeably better
+  // than the current one, jump straight to it.
+  useEffect(() => {
+    if (!isListening) return;
+
+    const id = window.setInterval(() => {
+      const { slides, currentIndex, currentSlide, mode } = propsRef.current;
+
+      // `slow` mode is strict: only the last-line trigger may advance. The
+      // periodic error-correction would otherwise jump on its own (advancing
+      // mid-slide / "by itself"), so it is disabled here.
+      if (mode === "slow") return;
+
+      const transcript = analysisWindow();
+      if (!transcript || slides.length === 0) return;
+
+      const best = matchSlide(transcript, slides);
+      if (best.slideIndex < 0 || best.slideIndex === currentIndex) return;
+
+      const currentScore = matchSlide(transcript, [currentSlide]).score;
+      if (best.score <= currentScore + CORRECTION_MARGIN) return;
+
+      // Backward jumps are riskier than forward ones, so they require a
+      // near-identical line on the target slide. And if that near-identical
+      // phrase appears on more than one slide (e.g. a chorus that repeats
+      // verbatim), there is no way to know which one is meant — so we ignore
+      // the jump entirely. Forward jumps stay loose (margin only).
+      if (best.slideIndex < currentIndex) {
+        if (best.score < BACKWARD_LINE_THRESHOLD) return;
+
+        const nearIdenticalCount = slides.filter(
+          (slide) => matchSlide(transcript, [slide]).score >= BACKWARD_LINE_THRESHOLD,
+        ).length;
+        if (nearIdenticalCount > 1) return;
+      }
+
+      advanceTo(best.slideIndex);
+    }, CORRECTION_INTERVAL_MS);
+
+    return () => window.clearInterval(id);
+  }, [isListening, advanceTo, analysisWindow]);
+
+  // Tear everything down on unmount.
+  useEffect(() => {
+    return () => {
+      shouldListenRef.current = false;
+      const recognition = recognitionRef.current;
+      if (recognition) {
+        recognition.onresult = null;
+        recognition.onerror = null;
+        recognition.onend = null;
+        try {
+          recognition.abort();
+        } catch {
+          // Ignore.
+        }
+      }
+    };
+  }, []);
+
+  return { isListening, isSupported, start, stop, lastTranscript, confidence };
+}

--- a/app/src/lib/__tests__/fuzzy.spec.ts
+++ b/app/src/lib/__tests__/fuzzy.spec.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { matchSlide, normalizeText, similarity } from "../fuzzy";
+
+describe("fuzzy", () => {
+  describe("normalizeText", () => {
+    it("removes accents/diacritics", () => {
+      expect(normalizeText("Coração")).toBe("coracao");
+      expect(normalizeText("São João é ótimo")).toBe("sao joao e otimo");
+    });
+
+    it("lowercases", () => {
+      expect(normalizeText("HELLO World")).toBe("hello world");
+    });
+
+    it("removes punctuation", () => {
+      expect(normalizeText("Olá, mundo!!! (teste)")).toBe("ola mundo teste");
+    });
+
+    it("collapses and trims whitespace", () => {
+      expect(normalizeText("  a   b\tc  ")).toBe("a b c");
+    });
+
+    it("returns an empty string for empty input", () => {
+      expect(normalizeText("")).toBe("");
+    });
+  });
+
+  describe("similarity", () => {
+    it("returns 1 for identical strings", () => {
+      expect(similarity("hello world", "hello world")).toBe(1);
+    });
+
+    it("returns 1 ignoring case, accents and punctuation", () => {
+      expect(similarity("Coração!", "coracao")).toBe(1);
+    });
+
+    it("returns 0 for strings with nothing in common", () => {
+      expect(similarity("abcdef", "wxyz")).toBe(0);
+    });
+
+    it("returns 0 when either string is empty", () => {
+      expect(similarity("", "hello")).toBe(0);
+      expect(similarity("hello", "")).toBe(0);
+    });
+
+    it("returns a partial score strictly between 0 and 1", () => {
+      const score = similarity("hello world", "hello there");
+      expect(score).toBeGreaterThan(0);
+      expect(score).toBeLessThan(1);
+    });
+  });
+
+  describe("matchSlide", () => {
+    const slides: string[][] = [
+      ["Amazing grace how sweet the sound", "That saved a wretch like me"],
+      ["I once was lost", "But now am found"],
+      ["Was blind but now I see", "Twas grace that taught my heart to fear"],
+    ];
+
+    it("finds the slide and line that best match the transcript", () => {
+      const result = matchSlide("but now am found", slides);
+      expect(result.slideIndex).toBe(1);
+      expect(result.lineIndex).toBe(1);
+      expect(result.score).toBeGreaterThan(0.6);
+    });
+
+    it("matches the correct slide even with recognition noise", () => {
+      const result = matchSlide("amazing grace how sweet sound", slides);
+      expect(result.slideIndex).toBe(0);
+      expect(result.lineIndex).toBe(0);
+    });
+
+    it("returns slideIndex -1 when there are no slides", () => {
+      const result = matchSlide("anything", []);
+      expect(result.slideIndex).toBe(-1);
+      expect(result.score).toBe(0);
+    });
+  });
+});

--- a/app/src/lib/fuzzy.ts
+++ b/app/src/lib/fuzzy.ts
@@ -1,0 +1,140 @@
+/**
+ * Fuzzy text-matching utilities used by the voice-driven slide auto-advance.
+ *
+ * Everything here is dependency-free and deterministic so it can be unit-tested
+ * in isolation and run cheaply on every speech-recognition result.
+ */
+
+export interface SlideMatch {
+  slideIndex: number;
+  lineIndex: number;
+  score: number;
+}
+
+/**
+ * Normalizes a piece of text for comparison:
+ * - removes diacritics/accents (á → a, ç → c)
+ * - lowercases
+ * - strips punctuation (anything that is not a letter, digit or whitespace)
+ * - collapses runs of whitespace and trims
+ */
+export function normalizeText(text: string): string {
+  if (!text) return "";
+  return text
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "") // strip combining accent marks
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ") // drop punctuation
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Builds the multiset of character bigrams of a string. */
+function bigrams(value: string): Map<string, number> {
+  const grams = new Map<string, number>();
+  for (let i = 0; i < value.length - 1; i++) {
+    const gram = value.slice(i, i + 2);
+    grams.set(gram, (grams.get(gram) ?? 0) + 1);
+  }
+  return grams;
+}
+
+/**
+ * Similarity between two strings in the [0, 1] range using the Sørensen–Dice
+ * coefficient over character bigrams (an n-gram approach). The inputs are
+ * normalized first, so case, accents and punctuation are ignored.
+ *
+ * - identical (non-empty) strings → 1
+ * - strings with nothing in common → 0
+ * - partial overlap → a value strictly between 0 and 1
+ */
+export function similarity(a: string, b: string): number {
+  const na = normalizeText(a);
+  const nb = normalizeText(b);
+
+  if (na.length === 0 || nb.length === 0) return 0;
+  if (na === nb) return 1;
+  // Single-character strings have no bigrams; fall back to equality.
+  if (na.length < 2 || nb.length < 2) return na === nb ? 1 : 0;
+
+  const aGrams = bigrams(na);
+  const bGrams = bigrams(nb);
+
+  let aTotal = 0;
+  for (const count of aGrams.values()) aTotal += count;
+
+  let bTotal = 0;
+  let intersection = 0;
+  for (const [gram, count] of bGrams) {
+    bTotal += count;
+    const inA = aGrams.get(gram);
+    if (inA) intersection += Math.min(inA, count);
+  }
+
+  return (2 * intersection) / (aTotal + bTotal);
+}
+
+/**
+ * Best similarity between a single `line` and the most relevant slice of a
+ * (possibly long, accumulated) `transcript`.
+ *
+ * Speech recognition produces a growing buffer, so comparing the whole buffer
+ * against a short line would unfairly dilute the score. We therefore slide a
+ * word-window roughly the size of the line across the transcript and keep the
+ * best match.
+ */
+export function scoreLine(transcript: string, line: string): number {
+  const normLine = normalizeText(line);
+  const normTranscript = normalizeText(transcript);
+  if (!normLine || !normTranscript) return 0;
+
+  // Whole-buffer comparison as a baseline.
+  let best = similarity(normTranscript, normLine);
+  if (best === 1) return 1;
+
+  const transcriptWords = normTranscript.split(" ");
+  const lineWordCount = normLine.split(" ").length;
+
+  // Try window sizes around the line length to tolerate insertions/deletions
+  // introduced by the recognizer.
+  const sizes = new Set<number>();
+  for (const size of [lineWordCount - 1, lineWordCount, lineWordCount + 1, lineWordCount + 2]) {
+    if (size >= 1 && size <= transcriptWords.length) sizes.add(size);
+  }
+
+  for (const size of sizes) {
+    for (let start = transcriptWords.length - size; start >= 0; start--) {
+      const windowText = transcriptWords.slice(start, start + size).join(" ");
+      const score = similarity(windowText, normLine);
+      if (score > best) {
+        best = score;
+        if (best === 1) return 1;
+      }
+    }
+  }
+
+  return best;
+}
+
+/**
+ * Finds the slide + line that best matches the given transcript.
+ *
+ * `slides` is an array of slides, each being an array of text lines. The
+ * returned `score` is in [0, 1]; when no slide/line is available the indices
+ * are -1 and the score is 0.
+ */
+export function matchSlide(transcript: string, slides: string[][]): SlideMatch {
+  let best: SlideMatch = { slideIndex: -1, lineIndex: -1, score: 0 };
+
+  for (let slideIndex = 0; slideIndex < slides.length; slideIndex++) {
+    const lines = slides[slideIndex];
+    for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+      const score = scoreLine(transcript, lines[lineIndex]);
+      if (score > best.score) {
+        best = { slideIndex, lineIndex, score };
+      }
+    }
+  }
+
+  return best;
+}

--- a/app/src/lib/storage-keys.ts
+++ b/app/src/lib/storage-keys.ts
@@ -4,4 +4,5 @@ export const STORAGE_KEYS = {
   broadcastSession: 'broadcastSession',
   controllerConfig: 'controllerConfig',
   controllerSchedule: 'controllerSchedule',
+  voiceAdvanceMode: 'voiceAdvanceMode',
 } as const;


### PR DESCRIPTION
Adds hands-free slide advancing on the live controller using the browser Web Speech API (pt-BR), with dependency-free fuzzy matching.

- lib/fuzzy.ts: normalizeText, similarity (Dice/bigrams), scoreLine, matchSlide
- hooks/useVoiceAutoAdvance.ts: continuous recognition, word-count consume buffer, periodic error-correction, and two modes — normal (advance when the slide is recognized, tolerant of a misheard final word) and slow (last line only, no auto-correction)
- components/controller/controls.tsx: mic toggle + normal/slow mode switch with persistence; live transcript overlay
- live-panel: enable voice via showVoice
- i18n (en/pt) and storage key for the voice mode
- tests for fuzzy and the hook